### PR TITLE
Fix scheduler arguments for torque

### DIFF
--- a/R/pipeline_functions.R
+++ b/R/pipeline_functions.R
@@ -49,7 +49,7 @@ get_job_sched_args <- function(scfg=NULL, job_name) {
      )
    } else {
      sched_args <- glue(
-       "-l nodes1:ppn={scfg[[job_name]]$ncores}",
+       "-l nodes=1:ppn={scfg[[job_name]]$ncores}",
        "-l walltime={hours_to_dhms(scfg[[job_name]]$nhours)}",
        "-l mem={scfg[[job_name]]$memgb}",
        "{sched_args}",

--- a/tests/testthat/test-get_job_sched_args.R
+++ b/tests/testthat/test-get_job_sched_args.R
@@ -1,0 +1,32 @@
+library(testthat)
+library(BrainGnomes)
+
+test_that("get_job_sched_args formats torque arguments", {
+  scfg <- list(
+    compute_environment = list(scheduler = "torque"),
+    myjob = list(ncores = 4, nhours = 2, memgb = 8, sched_args = NULL)
+  )
+  result <- get_job_sched_args(scfg, "myjob")
+  expect_equal(
+    result,
+    glue::glue(
+      "-l nodes=1:ppn=4 -l walltime=02:00:00 -l mem=8",
+      .trim = TRUE, .sep = " ", .null = NULL
+    )
+  )
+})
+
+test_that("get_job_sched_args formats slurm arguments", {
+  scfg <- list(
+    compute_environment = list(scheduler = "slurm"),
+    myjob = list(ncores = 4, nhours = 2, memgb = 8, sched_args = NULL)
+  )
+  result <- get_job_sched_args(scfg, "myjob")
+  expect_equal(
+    result,
+    glue::glue(
+      "-N 1 -n 4 --time=02:00:00 --mem=8g",
+      .trim = TRUE, .sep = " ", .null = NULL
+    )
+  )
+})


### PR DESCRIPTION
## Summary
- fix torque scheduler argument in `get_job_sched_args`
- add regression tests for scheduler string construction

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abc0324b48321b5b88d0d26a84373