### PR TITLE
Add enable flags for optional pipeline stages

### DIFF
--- a/R/setup_postprocess.R
+++ b/R/setup_postprocess.R
@@ -15,8 +15,19 @@ setup_postprocess <- function(scfg = list(), fields = NULL) {
     cli_options = "",
     sched_args = ""
   )
- 
-  scfg <- setup_job(scfg, "postprocess", defaults, fields) 
+
+  scfg <- setup_job(scfg, "postprocess", defaults, fields)
+
+  if (is.null(fields)) {
+    fields <- c()
+    if (is.null(scfg$postprocess$enable)) fields <- c(fields, "postprocess/enable")
+  }
+
+  if ("postprocess/enable" %in% fields) {
+    scfg$postprocess$enable <- prompt_input("Run postprocessing?", type = "flag", default = TRUE)
+  }
+
+  if (isFALSE(scfg$postprocess$enable) && is.null(fields)) return(scfg)
   scfg <- setup_postprocess_globals(scfg, fields)
   scfg <- setup_spatial_smooth(scfg, fields)
   scfg <- setup_apply_aroma(scfg, fields)


### PR DESCRIPTION
## Summary
- add enable toggles for BIDS conversion, validation, fMRIPrep, MRIQC and postprocessing
- skip configuration prompts when steps are disabled
- update compute environment setup to only request container paths for enabled steps
- gate run_project execution and prompts on step enable flags
- fix enable check placement for setup_fmriprep
- move enable flag checks after setup_job to preserve field arguments

## Testing
- `R CMD build` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685afdad06548321bbc33a1bb05c67e3