### PR TITLE
Fix sbatch background exit statuses

### DIFF
--- a/inst/hpc_scripts/aroma_subject.sbatch
+++ b/inst/hpc_scripts/aroma_subject.sbatch
@@ -66,9 +66,14 @@ log_message INFO Starting aroma for subject $sub_id with mem: $mem and cpus: $SL
 rel $rel_flag $log_flag $singularity_cmd \
     "$loc_bids_root" "$loc_mrproc_root/" participant \
     $cli_options & # all options setup by submit_aroma()
+cmd_pid=$!
 
-wait
+set +e
+wait $cmd_pid
+cmd_status=$?
+set -e
 
-[[ $? -eq 0 && $debug_pipeline -eq 0 ]] && date +"%Y-%m-%d %H:%M:%S" > "$complete_file"
+[[ $cmd_status -eq 0 && $debug_pipeline -eq 0 ]] && date +"%Y-%m-%d %H:%M:%S" > "$complete_file"
 
 log_message INFO Finished aroma for subject $sub_id "(time elapsed: $(time_elapsed))"
+exit $cmd_status

--- a/inst/hpc_scripts/bids_conversion_subject.sbatch
+++ b/inst/hpc_scripts/bids_conversion_subject.sbatch
@@ -74,13 +74,18 @@ singularity_cmd="singularity run --cleanenv -B $loc_bids_root -B $loc_sub_dicoms
 rel $rel_flag $log_flag $singularity_cmd --files $loc_sub_dicoms -s $sub_id $ses_flag \
   -f $heudiconv_heuristic -c dcm2niix \
   -o $loc_bids_root --bids &
+cmd_pid=$!
 
-wait
+set +e
+wait $cmd_pid
+cmd_status=$?
+set -e
 
 # write complete file if the command was successful and debug_pipeline is not set
-[[ $? -eq 0 && $debug_pipeline -eq 0 ]] && date +"%Y-%m-%d %H:%M:%S" > "$complete_file"
+[[ $cmd_status -eq 0 && $debug_pipeline -eq 0 ]] && date +"%Y-%m-%d %H:%M:%S" > "$complete_file"
 
 log_message INFO Finished heudiconv for subject $sub_id $ses_str "(time elapsed: $(time_elapsed))"
+exit $cmd_status
 
 #######
 # example call

--- a/inst/hpc_scripts/fmriprep_subject.sbatch
+++ b/inst/hpc_scripts/fmriprep_subject.sbatch
@@ -100,9 +100,14 @@ rel $rel_flag $log_flag export APPTAINERENV_FS_LICENSE="$fs_license_file" # set 
 rel $rel_flag $log_flag $singularity_cmd \
     "$loc_bids_root" "$loc_mrproc_root/" participant \
     $cli_options & # all options setup by submit_fmriprep()
+cmd_pid=$!
 
-wait
+set +e
+wait $cmd_pid
+cmd_status=$?
+set -e
 
-[[ $? -eq 0 && $debug_pipeline -eq 0 ]] && date +"%Y-%m-%d %H:%M:%S" > "$complete_file"
+[[ $cmd_status -eq 0 && $debug_pipeline -eq 0 ]] && date +"%Y-%m-%d %H:%M:%S" > "$complete_file"
 
 log_message INFO "Finished fmriprep for subject $sub_id $ses_str (time elapsed: $(time_elapsed))"
+exit $cmd_status

--- a/inst/hpc_scripts/mriqc_subject.sbatch
+++ b/inst/hpc_scripts/mriqc_subject.sbatch
@@ -62,9 +62,14 @@ log_message INFO Starting mriqc for subject $sub_id in $out_dir
 rel $rel_flag $log_flag $singularity_cmd \
     "$loc_bids_root" "$loc_mriqc_root/" participant \
     $cli_options & # all options setup by submit_mriqc()
+cmd_pid=$!
 
-wait
+set +e
+wait $cmd_pid
+cmd_status=$?
+set -e
 
-[[ $? -eq 0 && $debug_pipeline -eq 0 ]] && date +"%Y-%m-%d %H:%M:%S" > "$complete_file"
+[[ $cmd_status -eq 0 && $debug_pipeline -eq 0 ]] && date +"%Y-%m-%d %H:%M:%S" > "$complete_file"
 
 log_message INFO Finished mriqc for subject $sub_id
+exit $cmd_status

--- a/inst/hpc_scripts/postprocess_image_subject.sbatch
+++ b/inst/hpc_scripts/postprocess_image_subject.sbatch
@@ -72,7 +72,12 @@ start_time=$(date +%s)
 log_message INFO Starting postprocessing for image $input_file in $out_dir with mem: $mem
 
 rel $rel_flag $log_flag Rscript --vanilla "$postproc_rscript" --input="$input_file" $postproc_cli &
-    
-wait
+cmd_pid=$!
+
+set +e
+wait $cmd_pid
+cmd_status=$?
+set -e
 
 log_message INFO Finished postprocessing for image $input_file "(time elapsed: $(time_elapsed))"
+exit $cmd_status


### PR DESCRIPTION
## Summary
- ensure sbatch scripts properly capture exit status when running compute commands in the background
- exit with the captured status so the scheduler receives success or failure correctly

## Testing
- `R CMD build .`
- `R CMD check BrainGnomes_0.2-3.tar.gz` *(fails: cannot access cloud.r-project.org)*

------
https://chatgpt.com/codex/tasks/task_e_686433751fac8321a08ddb737f5400cd