### PR TITLE
Normalize debug flag in HPC scripts

### DIFF
--- a/inst/hpc_scripts/bids_conversion_subject.pbs
+++ b/inst/hpc_scripts/bids_conversion_subject.pbs
@@ -33,6 +33,9 @@ source "$env_file" #setup relevant variables for this processing environment
 [ -z "${loc_bids_root}" ] && echo "No loc_bids_root variable set." && exit 1
 
 ####
+# convert debug flag to numeric
+[[ "$debug_pipeline" == "TRUE" ]] && debug_pipeline=1 || debug_pipeline=0
+
 #run heudiconv
 [[ "$debug_pipeline" -eq 1 ]] && rel_suffix=c #if debug_pipeline is 1, only echo command to log, don't run it
 rel "${heudiconv_location} -d ${loc_mrraw_root}/{subject}/*/*.dcm -s $sub -f ${heudiconv_heuristic} -c dcm2niix -o ${loc_bids_root} -b && date \"+%m%d%y@%H:%M\" > ${loc_bids_root}/sub-${sub}/.heudiconv_complete" $rel_suffix

--- a/inst/hpc_scripts/fmriprep_subject.pbs
+++ b/inst/hpc_scripts/fmriprep_subject.pbs
@@ -30,6 +30,8 @@ source "$env_file" #setup relevant variables for this processing environment
 [ -z "$sub_id" ] && echo "sub_id not set. Exiting." && exit 1
 
 ####
+[[ "$debug_pipeline" == "TRUE" ]] && debug_pipeline=1 || debug_pipeline=0 # set debug_pipeline to 1 if it is set to TRUE, otherwise set it to 0
+
 [[ "$debug_pipeline" -eq 1 ]] && rel_suffix=c #if debug_pipeline is 1, only echo command to log, don't run it
 rel "${pipedir}/fmriprep_wrapper ${loc_bids_root} ${loc_mrproc_root}/ participant --participant_label $sub --nthreads $fmriprep_nthreads -w ${loc_root}/fmriprep_tempfiles && date \"+%m%d%y@%H:%M\" > $loc_bids_root/sub-$sub/.fmriprep_complete" $rel_suffix
 

--- a/inst/hpc_scripts/mriqc_subject.pbs
+++ b/inst/hpc_scripts/mriqc_subject.pbs
@@ -51,5 +51,7 @@ module load fsl/5.0.11 #Using version 6 of FSL creates problems
 [ -z "${loc_root}" ] && echo "No loc_root variable set." && exit 1
 
 ####
+[[ "$debug_pipeline" == "TRUE" ]] && debug_pipeline=1 || debug_pipeline=0 # set debug_pipeline to 1 if it is set to TRUE, otherwise set it to 0
+
 [[ "$debug_pipeline" -eq 1 ]] && rel_suffix=c #if debug_pipeline is 1, only echo command to log, don't run it
 rel "${mriqc_location} ${loc_root}/bids/ ${loc_root}/mriqc_IQMs/ participant --participant-label $sub -w ${loc_root}/mriqc_tempfiles && date \"+%m%d%y@%H:%M\" > $loc_bids_root/sub-$sub/.mriqc_complete" $rel_suffix

--- a/inst/hpc_scripts/postprocess_image_subject.sbatch
+++ b/inst/hpc_scripts/postprocess_image_subject.sbatch
@@ -42,6 +42,8 @@ ncores=$SLURM_NTASKS
 [ ! -r "$input_file" ] && echo "input_file $input_file not readable. Exiting" && exit 1
 [ -z "$log_file" ] && echo "log_file not set. Exiting" && exit 1
 
+[[ "$debug_pipeline" == "TRUE" ]] && debug_pipeline=1 || debug_pipeline=0 # set debug_pipeline to 1 if it is set to TRUE, otherwise set it to 0
+
 # add the job id to the log file variables in case of crash
 [ -z "$stdout_log" ] && echo "stdout_log not set. Exiting." && exit 1
 [ -z "$stderr_log" ] && echo "stderr_log not set. Exiting." && exit 1

--- a/inst/hpc_scripts/postprocess_subject.sbatch
+++ b/inst/hpc_scripts/postprocess_subject.sbatch
@@ -40,6 +40,7 @@ ncores=$SLURM_NTASKS
 [ ! -f "$postproc_image_sched_script" ] && echo "postproc_image_sched_script $postproc_image_sched_script not found. Exiting" && exit 1
 [ ! -r "$postproc_image_sched_script" ] && echo "postproc_image_sched_script $postproc_image_sched_script not readable. Exiting" && exit 1
 [ -z "$debug_pipeline" ] && debug_pipeline=0
+[[ "$debug_pipeline" == "TRUE" ]] && debug_pipeline=1 || debug_pipeline=0 # set debug_pipeline to 1 if it is set to TRUE, otherwise set it to 0
 [ -z "$sub_id" ] && echo "sub_id not set. Exiting." && exit 1
 
 # add the job id to the log file variables in case of crash


### PR DESCRIPTION
## Summary
- normalize `debug_pipeline` at start of HPC scripts
- use numeric check for debug flag in PBS jobs

## Testing
- `Rscript -e 'devtools::test()'`

------
https://chatgpt.com/codex/tasks/task_e_68644820dbe08321aa6715eaf14f2d81