### PR TITLE
Forward R_HOME to HPC jobs

### DIFF
--- a/R/process_subject.R
+++ b/R/process_subject.R
@@ -69,6 +69,7 @@ process_subject <- function(scfg, sub_cfg = NULL, steps = NULL) {
     env_variables <- c(
       debug_pipeline = scfg$debug,
       pkg_dir = system.file(package = "BrainGnomes"), # root of inst folder for installed R package
+      R_HOME = R.home(),
       log_file = lg$appenders$subject_logger$destination, # write to same file as subject lgr
       stdout_log = glue("{scfg$metadata$log_directory}/sub-{sub_id}/{jobid_str}_jobid-%j_{format(Sys.time(), '%d%b%Y_%H.%M.%S')}.out"),
       stderr_log = glue("{scfg$metadata$log_directory}/sub-{sub_id}/{jobid_str}_jobid-%j_{format(Sys.time(), '%d%b%Y_%H.%M.%S')}.err"),

--- a/R/run_bids_validation.R
+++ b/R/run_bids_validation.R
@@ -34,6 +34,7 @@ run_bids_validation <- function(scfg, outfile = NULL) {
   env_variables <- c(
     debug_pipeline = scfg$debug,
     pkg_dir = system.file(package = "BrainGnomes"),
+    R_HOME = R.home(),
     log_file = log_file,
     stdout_log = glue::glue("{scfg$metadata$log_directory}/bids_validation_jobid-%j_{format(Sys.time(), '%d%b%Y_%H.%M.%S')}.out"),
     stderr_log = glue::glue("{scfg$metadata$log_directory}/bids_validation_jobid-%j_{format(Sys.time(), '%d%b%Y_%H.%M.%S')}.err")

--- a/inst/hpc_scripts/postprocess_image_subject.sbatch
+++ b/inst/hpc_scripts/postprocess_image_subject.sbatch
@@ -15,9 +15,6 @@ set -eE  # 'E' ensures ERR trap inherits in functions/subshells
 [ -z "$pkg_dir" ] && echo "pkg_dir not set. Cannot locate required helper scripts" && exit 1
 source "${pkg_dir}/shell_functions"
 
-# Load the right instance of R to make this go -- TODO: need to abstract this as a configuration step
-module use /proj/mnhallqlab/sw/modules
-module load r/4.2.1
 
 # Set trap for common termination signals
 trap 'trap_job_failure postprocess SIGTERM' SIGTERM
@@ -81,7 +78,7 @@ start_time=$(date +%s)
 
 log_message INFO Starting postprocessing for image $input_file in $out_dir with mem: $mem
 
-rel $rel_flag $log_flag Rscript --vanilla "$postproc_rscript" --input="$input_file" $postproc_cli &
+rel $rel_flag $log_flag "${R_HOME}/bin/Rscript" --vanilla "$postproc_rscript" --input="$input_file" $postproc_cli &
 cmd_pid=$!
 
 set +e


### PR DESCRIPTION
## Summary
- pass `R_HOME` as an environment variable to job scripts
- use `${R_HOME}/bin/Rscript` for postprocess image script
- remove static module loading from `postprocess_image_subject.sbatch`

## Testing
- `devtools::test()`

------
https://chatgpt.com/codex/tasks/task_e_68651c2b57bc83218af8214bb201c085