### PR TITLE
Add scrubbing step with spike regressors

### DIFF
--- a/R/edit_project.R
+++ b/R/edit_project.R
@@ -66,6 +66,7 @@ edit_project <- function(input) {
       "intensity_normalize/global_median", "intensity_normalize/prefix",
       "confound_calculate/columns", "confound_calculate/noproc_columns",
       "confound_calculate/demean",
+      "scrubbing/expression",
       "confound_regression/columns", "confound_regression/noproc_columns",
       "confound_regression/prefix",
       "force_processing_order", "processing_steps"

--- a/R/validate_project.R
+++ b/R/validate_project.R
@@ -304,6 +304,14 @@ validate_postprocess_config <- function(ppcfg, quiet = FALSE) {
     }
   }
 
+  if ("scrubbing" %in% names(ppcfg)) {
+    if (!checkmate::test_character(ppcfg$scrubbing$expression)) {
+      if (!quiet) message("Invalid expression field in $postprocess$scrubbing")
+      gaps <- c(gaps, "postprocess/scrubbing/expression")
+      ppcfg$scrubbing$expression <- NULL
+    }
+  }
+
   if ("confound_regression" %in% names(ppcfg)) {
     if (!checkmate::test_character(ppcfg$confound_regression$columns)) {
       if (!quiet) message("Invalid columns field in $postprocess$confound_regression")

--- a/tests/example_config.yaml
+++ b/tests/example_config.yaml
@@ -89,6 +89,9 @@ postprocess:
     columns: csf
     noproc_columns: .na.character
     demean: yes
+  scrubbing:
+    enable: no
+    expression: fd > 0.9
   confound_regression:
     enable: no
   force_processing_order: no

--- a/tests/testthat/test-compute_spike_regressors.R
+++ b/tests/testthat/test-compute_spike_regressors.R
@@ -1,0 +1,10 @@
+library(testthat)
+library(BrainGnomes)
+
+test_that("compute_spike_regressors identifies spikes", {
+  mot <- data.frame(fd = c(0.1, 0.6, 0.2, 0.7))
+  spikes <- BrainGnomes:::compute_spike_regressors(mot, "fd > 0.5", lg = lgr::get_logger())
+  expect_equal(nrow(spikes), 4)
+  expect_equal(ncol(spikes), 2)
+  expect_equal(colSums(spikes), c(1, 1))
+})


### PR DESCRIPTION
## Summary
- implement `compute_spike_regressors` helper
- add optional scrubbing step to postprocessing
- generate spike regressors and censor files
- include scrubbing configuration and editing options
- validate scrubbing config
- document example config and tests

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_686551aa47308321a0e6bbb89a6a7a5b