### PR TITLE
Enable regex patterns for confound columns

### DIFF
--- a/tests/testthat/test-expand_confound_columns.R
+++ b/tests/testthat/test-expand_confound_columns.R
@@ -1,0 +1,22 @@
+test_that("expand_confound_columns expands regex and angle brackets", {
+  available <- c(
+    "motion_param_1", "motion_param_2", "motion_param_3",
+    "motion_param_25", "csf", "white_matter",
+    "motion_parameter_1", "motion_parameter_12", "motion_parameter_0"
+  )
+
+  expect_equal(
+    expand_confound_columns("motion_param_<1-3>", available),
+    c("motion_param_1", "motion_param_2", "motion_param_3")
+  )
+
+  expect_equal(
+    expand_confound_columns("motion_param_<1,25>", available),
+    c("motion_param_1", "motion_param_25")
+  )
+
+  expect_setequal(
+    expand_confound_columns("motion_parameter_[1-9]+", available),
+    c("motion_parameter_1", "motion_parameter_12")
+  )
+})


### PR DESCRIPTION
## Summary
- add helper `expand_confound_columns` for PCRE and `<n>` expansion
- use the helper in `postprocess_confounds`
- test regex/range column expansion

## Testing
- `apt-get install -y r-base-core` *(fails: unable to locate package)*
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d597b619883218950fc98ef16392a