### PR TITLE
Interactive postprocess stream setup

### DIFF
--- a/R/process_subject.R
+++ b/R/process_subject.R
@@ -31,7 +31,7 @@ process_subject <- function(scfg, sub_cfg = NULL, steps = NULL, postprocess_stre
     if (any(duplicated(sub_cfg$ses_id))) stop("Duplicate session IDs found in sub_cfg. process_subject requires unique session IDs.")
   }
   checkmate::assert_logical(steps, names = "unique")
-  checkmate::assert_character(postprocess_streams, null.ok = TRUE any.missing = FALSE)
+  checkmate::assert_character(postprocess_streams, null.ok = TRUE, any.missing = FALSE)
   expected <- c("bids_conversion", "mriqc", "fmriprep", "aroma", "postprocess")
   for (ee in expected) if (is.na(steps[ee])) steps[ee] <- FALSE # ensure we have valid logicals for expected fields
 

--- a/R/setup_project.R
+++ b/R/setup_project.R
@@ -77,7 +77,7 @@ setup_project <- function(input = NULL, fields = NULL) {
   scfg <- setup_fmriprep(scfg, fields)
   scfg <- setup_mriqc(scfg, fields)
   scfg <- setup_aroma(scfg, fields)
-  scfg <- setup_postprocess(scfg, fields)
+  scfg <- setup_postprocess_streams(scfg, fields)
   scfg <- setup_compute_environment(scfg, fields)
 
   scfg <- save_project_config(scfg)


### PR DESCRIPTION
## Summary
- add `setup_postprocess_streams` for managing multiple postprocessing configs
- prompt for postprocess stream management during `setup_project`
- allow editing of postprocess configurations by name
- fix argument typo in `process_subject`

## Testing
- `R -q -e "devtools::test()"` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_688027d697a48321b60982a90146d847