### PR TITLE
Add test coverage for CLI and misc utilities

### DIFF
--- a/tests/testthat/test-cli_utils.R
+++ b/tests/testthat/test-cli_utils.R
@@ -1,0 +1,46 @@
+# tests for CLI utility functions
+
+library(testthat)
+
+# args_to_df handles equals and space-separated values
+
+test_that("args_to_df parses CLI arguments", {
+  args <- c("--foo=1", "--bar", "2 3", "-x=hello")
+  df <- args_to_df(args)
+  expect_equal(nrow(df), 3)
+  expect_equal(df$lhs, c("foo", "bar", "x"))
+  expect_equal(df$rhs, c("1", "2 3", "hello"))
+  expect_equal(df$has_equals, c(TRUE, FALSE, TRUE))
+  expect_equal(df$nhyphens, c(2, 2, 1))
+})
+
+# parse_cli_args builds nested list
+
+test_that("parse_cli_args converts CLI arguments to nested list", {
+  args <- c("--a/b=10", "--c=d", "--flag e f")
+  res <- parse_cli_args(args)
+  expect_equal(res$a$b, 10)
+  expect_equal(res$c, "d")
+  expect_equal(res$flag, "e f")
+})
+
+# nested_list_to_args round-trips with parse_cli_args
+
+test_that("nested_list_to_args creates expected CLI strings", {
+  lst <- list(a = list(b = 1, c = 2), d = "hey")
+  args <- nested_list_to_args(lst)
+  expect_true(all(c("--a/b='1'", "--a/c='2'", "--d=hey") %in% args))
+  collapsed <- nested_list_to_args(lst, collapse = TRUE)
+  expect_true(grepl("--a/b='1'", collapsed, fixed = TRUE))
+  expect_true(grepl("--d=hey", collapsed, fixed = TRUE))
+})
+
+# set_cli_options merges and updates CLI args
+
+test_that("set_cli_options updates and adds options", {
+  base <- c("--foo=1", "--bar=2")
+  new <- c("--foo=3", "--baz=4")
+  result <- set_cli_options(base, new)
+  expect_equal(result, c("--foo=3", "--bar=2", "--baz=4"))
+})
+

--- a/tests/testthat/test-utils_misc.R
+++ b/tests/testthat/test-utils_misc.R
@@ -1,0 +1,27 @@
+# tests for miscellaneous utility functions
+
+library(testthat)
+
+# file_sans_ext removes common extensions
+
+test_that("file_sans_ext removes image extensions", {
+  expect_equal(file_sans_ext("test.nii.gz"), "test")
+  expect_equal(file_sans_ext("path/data.nii"), "path/data")
+  expect_true(is.na(file_sans_ext("file.txt2")))
+})
+
+# extract_bids_info extracts BIDS fields
+
+test_that("extract_bids_info parses filename entities", {
+  files <- c(
+    "sub-01_ses-02_task-memory_run-1_bold.nii.gz",
+    "sub-02_task-rest_bold.nii.gz"
+  )
+  df <- extract_bids_info(files)
+  expect_equal(df$subject, c("01", "02"))
+  expect_equal(df$session[1], "02")
+  expect_true(is.na(df$session[2]))
+  expect_equal(df$task, c("memory", "rest"))
+  expect_equal(df$run[1], "1")
+})
+


### PR DESCRIPTION
## Summary
- add `test-cli_utils.R` with tests for CLI helpers
- add `test-utils_misc.R` with tests for file helpers and BIDS parsing

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68881662a9b883219a91a925f99c6493