### PR TITLE
Prompt for subject IDs in interactive run_project

### DIFF
--- a/man/run_project.Rd
+++ b/man/run_project.Rd
@@ -21,9 +21,11 @@ Options are c("bids_conversion", "mriqc", "fmriprep", "aroma", "postprocess").
 If \code{NULL}, the user will be prompted for which steps to run.}
 
 \item{subject_filter}{Optional character vector or data.frame specifying which
-subjects (and optionally sessions) to process. When a data.frame is
-provided, it must contain a \code{sub_id} column and may include a \code{ses_id}
-column to filter on specific subject/session combinations.}
+subjects (and optionally sessions) to process. When \code{NULL} and run
+interactively, the user will be prompted to enter space-separated subject IDs
+(press ENTER to process all subjects). When a data.frame is provided, it must
+contain a \code{sub_id} column and may include a \code{ses_id} column to filter
+on specific subject/session combinations.}
 
 \item{postprocess_streams}{Optional character vector specifying which postprocessing streams should be run. If
 \verb{"postprocess"`` is included in }steps`, then this setting lets the user choose streams. If NULL, all postprocess


### PR DESCRIPTION
## Summary
- ask for space-separated subject IDs in interactive `run_project` and use them as `subject_filter`
- document the new subject ID prompt for interactive runs

## Testing
- `R -q -e 'devtools::test()'` *(fails: dependencies 'lgr', 'RNifti', 'signal' are not available)*

------
https://chatgpt.com/codex/tasks/task_e_689370e105688321b3e2cddb7efba472