### PR TITLE
Handle equals signs inside CLI argument values

### DIFF
--- a/R/cli_functions.R
+++ b/R/cli_functions.R
@@ -55,6 +55,10 @@ get_nested_values <- function(lst, key_strings, sep = "/", simplify = TRUE) {
 #' @param lst Optional list to update. If \code{NULL}, a new list is created.
 #' @param type_values Logical; whether to convert character values to appropriate types.
 #'
+#' Supports values containing `=` characters; only the first `=` is treated as the
+#' separator between key and value. Subsequent `=` characters are preserved in
+#' the value.
+#'
 #' @return A nested list with the specified keys and values.
 #' @importFrom utils modifyList
 #' @importFrom stats setNames
@@ -69,9 +73,14 @@ set_nested_values <- function(assignments, sep = "/", lst = NULL, type_values = 
   if (is.character(assignments)) {
     for (a in assignments) {
       parts <- strsplit(a, "=", fixed = TRUE)[[1]]
-      if (length(parts) != 2L) stop("Invalid assignment format: ", a)
+      if (length(parts) < 2L) stop("Invalid assignment format: ", a)
       key_str <- parts[1]
-      val_str <- parts[2]
+      if (length(parts) > 2L) {
+        # if additional equal signs are present, treat everything after the first as the value
+        val_str <- paste(parts[-1], collapse = "=")
+      } else {
+        val_str <- parts[2]
+      }
 
       keys <- strsplit(key_str, sep, fixed = TRUE)[[1]]
 
@@ -226,7 +235,7 @@ args_to_df <- function(arg_vec = NULL) {
           has_equals <- TRUE
           parts <- strsplit(token_naked, "=", fixed = TRUE)[[1]]
           lhs <- parts[1]
-          rhs_vals <- parts[2]
+          rhs_vals <- if (length(parts) > 1) paste(parts[-1], collapse = "=") else ""
           #to_parse <- c(parts[2], tokens)
         } else {
           has_equals <- FALSE

--- a/man/set_nested_values.Rd
+++ b/man/set_nested_values.Rd
@@ -22,5 +22,7 @@ A nested list with the specified keys and values.
 \description{
 Parses assignments like \code{"a/b/c=10"} or named lists like \code{list("a/b/c" = 10)} and returns
 \code{list(a = list(b = list(c = 10)))}.
+Supports values containing \code{=} characters; only the first \code{=} is
+treated as the separator between key and value.
 }
 \keyword{internal}

--- a/tests/testthat/test-cli_utils.R
+++ b/tests/testthat/test-cli_utils.R
@@ -25,6 +25,14 @@ test_that("parse_cli_args converts CLI arguments to nested list", {
   expect_equal(res$flag2, "e f") # quoted spaces parsed into string
 })
 
+# values containing '=' are parsed correctly
+test_that("parse_cli_args handles embedded equals signs", {
+  args <- c("--foo=bar=baz", "--bar='a=b'")
+  res <- parse_cli_args(args)
+  expect_equal(res$foo, "bar=baz")
+  expect_equal(res$bar, "a=b")
+})
+
 # nested_list_to_args round-trips with parse_cli_args
 
 test_that("nested_list_to_args creates expected CLI strings", {


### PR DESCRIPTION
## Summary
- Allow `set_nested_values()` to treat additional `=` characters as part of the value
- Preserve embedded `=` in `args_to_df()` so CLI parsing keeps full RHS values
- Test coverage for arguments that include `=` in their values and update docs

## Testing
- `Rscript -e "source('R/cli_functions.R'); testthat::test_file('tests/testthat/test-cli_utils.R', reporter='summary')"`
- `Rscript -e "devtools::test()"` *(fails: dependencies 'lgr', 'RNifti', 'signal' are not available)*

------
https://chatgpt.com/codex/tasks/task_e_6893bdd3779c83219357915f186a41d4