### PR TITLE
Allow BIDS entity input for postprocess regex

### DIFF
--- a/R/process_subject.R
+++ b/R/process_subject.R
@@ -422,6 +422,7 @@ sched_script = NULL, sched_args = NULL, parent_ids = NULL, lg = NULL, pp_stream 
   # pull the requested postprocessing stream from the broader list
   pp_cfg <- scfg$postprocess[[pp_stream]]
   pp_cfg$fsl_img <- scfg$compute_environment$aroma_container # always pass aroma container for running FSL commands in postprocessing
+  pp_cfg$input_regex <- construct_bids_regex(pp_cfg$input_regex)
   postprocess_cli <- nested_list_to_args(pp_cfg, collapse = TRUE) # create command line for calling postprocessing R script
   
   env_variables <- c(

--- a/R/setup_postprocess.R
+++ b/R/setup_postprocess.R
@@ -291,16 +291,15 @@ setup_postprocess_globals <- function(ppcfg = list(), fields = NULL, all_bids_de
   # global postprocessing settings
   if ("postprocess/input_regex" %in% fields) {
     ppcfg$input_regex <- prompt_input(
-      "What is the relevant file extension (or regular expression) for inputs?",
-      type = "character", len = 1L, default = ".*_desc-preproc_bold.nii.gz$",
+      "Which BIDS entries or regular expression identify the inputs?",
+      type = "character", len = 1L, default = "desc:preproc suffix:bold",
       instruct = glue("\n\n
       Postprocessing is typically only applied to BOLD data that have completed preprocessing in fmriprep.
       These files usually have a suffix like _desc-preproc_bold.nii.gz. However, you may have postprocessing settings
-      that only apply to certain outputs, such as for a particular experimental task or for resting state.
-
-      What is the file extension for functional data to be postprocessed? If, for example, you only want
-      files for a task called 'ridl', use a regular expression like, '.*_task-ridl.*_desc-preproc_bold.nii.gz$'. Note
-      that having the $ add the end of the regular expression ensures that the file ends with the specified suffix.\n
+      that only apply to certain outputs, such as for a particular experimental task or for resting state.\n\n
+      Provide BIDS entity pairs separated by spaces (e.g., 'task:ridl desc:preproc suffix:bold').
+      To supply an explicit regular expression instead, prefix it with 'regex:' such as
+      \"regex: .*_task-rest.*preproc.*\\.nii\\.gz$\".\n
       ")
     )
   }

--- a/inst/postprocess_cli.R
+++ b/inst/postprocess_cli.R
@@ -72,8 +72,9 @@ if (!checkmate::test_string(cfg$input)) stop("A valid --input must be provided p
 input_regex <- cfg$input_regex
 if (checkmate::test_directory(cfg$input)) {
   # input is a directory -- find all relevant nifti files to postprocess
-  if (is.null(input_regex)) input_regex <- ".*_desc-preproc_bold.nii.gz$"
-  input_files <- list.files(path=cfg$input, pattern=input_regex, recursive=TRUE, full.names = TRUE)
+  if (is.null(input_regex)) input_regex <- "desc:preproc suffix:bold"
+  input_regex <- BrainGnomes:::construct_bids_regex(input_regex)
+  input_files <- list.files(path = cfg$input, pattern = input_regex, recursive = TRUE, full.names = TRUE)
 } else if (!checkmate::test_file_exists(cfg$input)) {
   stop("A valid 4D NIfTI file to process must be passed in as --input=<4d file>")
 } else {

--- a/man/construct_bids_filename.Rd
+++ b/man/construct_bids_filename.Rd
@@ -11,7 +11,9 @@ construct_bids_filename(bids_df, full.names = FALSE)
 Must include at least the columns \code{suffix} and \code{ext}, and optionally:
 \code{subject}, \code{session}, \code{task}, \code{acquisition}, \code{run}, \code{modality}, \code{echo},
 \code{direction}, \code{reconstruction}, \code{hemisphere}, \code{space}, \code{resolution},
-\code{description}, and \code{fieldmap}.}
+\code{description}, and \code{fieldmap}. Column names may be given using full
+entity names or their abbreviated forms (e.g., \code{rec}, \code{desc});
+abbreviations are normalized internally.}
 
 \item{full.names}{If TRUE, return the full path to the file using the \verb{$directory}
 field of \code{bids_df}.}

--- a/tests/example_config.yaml
+++ b/tests/example_config.yaml
@@ -60,7 +60,7 @@ postprocess:
   ncores: 1
   cli_options: []
   sched_args: []
-  input_regex: .*space-MNI152NLin2009cAsym.*desc-preproc_bold.nii.gz$
+  input_regex: "regex: .*space-MNI152NLin2009cAsym.*desc-preproc_bold.nii.gz$"
   bids_desc: postproc
   keep_intermediates: no
   overwrite: no

--- a/tests/testthat/test-construct_bids_filename.R
+++ b/tests/testthat/test-construct_bids_filename.R
@@ -1,0 +1,15 @@
+test_that("construct_bids_filename accepts abbreviated entities", {
+  df <- data.frame(
+    sub = "01",
+    task = "rest",
+    rec = "abc",
+    desc = "preproc",
+    suffix = "bold",
+    ext = ".nii.gz",
+    stringsAsFactors = FALSE
+  )
+  expect_equal(
+    construct_bids_filename(df),
+    "sub-01_task-rest_rec-abc_desc-preproc_bold.nii.gz"
+  )
+})

--- a/vignettes/postprocessing.Rmd
+++ b/vignettes/postprocessing.Rmd
@@ -70,19 +70,25 @@ optional brain mask file are also collected.
 ### Selecting BOLD files with `input_regex`
 
 The `input_regex` setting controls which preprocessed NIfTI files are
-included. It accepts any POSIX regular expression, allowing you to
-target a subset of your fMRIPrep directory. For example, to postprocess
-only resting‐state runs you might supply:
+included. Instead of writing a full regular expression, you may supply
+BIDS entity-value pairs that are converted to a regex at runtime. For
+example:
 
 ```r
-.*task-rest.*_desc-preproc_bold\.nii\.gz$
+desc:preproc task:ridl suffix:bold
 ```
 
-This pattern matches any file containing `task-rest` and ending in
-`_desc-preproc_bold.nii.gz`. You could create another configuration for
-task-based data using a different expression. The prompts in
-`setup_postprocess_globals()` provide additional guidance and examples
-for constructing these expressions.【F:R/setup_postprocess.R†L199-L211】
+selects any file containing `task-ridl` and `desc-preproc` with a `bold`
+suffix, producing `.*_task-ridl.*_desc-preproc_bold.nii(.gz)?$`.
+
+To provide a custom regular expression, prefix it with `regex:`:
+
+```r
+regex: .*task-rest.*preproc.*\.nii\.gz$
+```
+
+The prompts in `setup_postprocess_globals()` provide additional guidance
+and examples for constructing these expressions.【F:R/setup_postprocess.R†L199-L211】
 
 ### Output naming with `bids_desc`
 


### PR DESCRIPTION
## Summary
- allow users to specify `postprocess/input_regex` via BIDS entity pairs or an explicit `regex:` prefix
- normalize abbreviated entity keys like `rec` or `desc` when constructing BIDS filenames
- document abbreviation support and add a regression test

## Testing
- `R -q -e 'devtools::test()'` *(fails: dependencies ‘lgr’, ‘RNifti’, ‘signal’ are not available for package ‘BrainGnomes’)*

------
https://chatgpt.com/codex/tasks/task_e_68937226e4a883218685ec712c287f6f