### PR TITLE
Fix BIDS regex entity anchoring

### DIFF
--- a/tests/testthat/test-construct_bids_filename.R
+++ b/tests/testthat/test-construct_bids_filename.R
@@ -1,0 +1,5 @@
+test_that("construct_bids_regex avoids partial matches", {
+  pattern <- construct_bids_regex("task:ridl desc:preproc suffix:bold")
+  expect_false(grepl(pattern, "sub-01_task-ridlye_desc-preproc_bold.nii.gz"))
+  expect_true(grepl(pattern, "sub-01_task-ridl_desc-preproc_bold.nii.gz"))
+})


### PR DESCRIPTION
## Summary
- add `construct_bids_regex` helper that requires underscore boundaries for each specified entity
- test that filenames with `task-ridlye` do not match `task:ridl` regex patterns

## Testing
- `R -q -e 'library(testthat); source("R/bids_functions.R"); testthat::test_file("tests/testthat/test-construct_bids_filename.R")'`


------
https://chatgpt.com/codex/tasks/task_e_689414fea328832193e9cbbf6e925136