### PR TITLE
Fix BIDS regex entity anchoring

### DIFF
--- a/tests/testthat/test-construct_bids_filename.R
+++ b/tests/testthat/test-construct_bids_filename.R
@@ -1,0 +1,11 @@
+test_that("construct_bids_regex avoids partial matches", {
+  pattern <- construct_bids_regex("task:ridl desc:preproc suffix:bold")
+  expect_false(grepl(pattern, "sub-01_task-ridlye_desc-preproc_bold.nii.gz"))
+  expect_true(grepl(pattern, "sub-01_task-ridl_desc-preproc_bold.nii.gz"))
+})
+
+test_that("construct_bids_regex accepts raw regex via regex: syntax", {
+  pattern <- construct_bids_regex("regex:sub-\\d+_task-ridl_.*_bold")
+  expect_equal(pattern, "sub-\\d+_task-ridl_.*_bold")
+  expect_true(grepl(pattern, "sub-01_task-ridl_desc-preproc_bold.nii.gz"))
+})


### PR DESCRIPTION
## Summary
- handle entity abbreviations in `construct_bids_filename` so downstream helpers understand shorthand keys
- extend `construct_bids_regex` with `regex:` passthrough and underscore-delimited token matching
- add tests covering regex passthrough and guarding against partial entity matches

## Testing
- `R -q -e 'library(testthat); source("R/bids_functions.R"); testthat::test_file("tests/testthat/test-construct_bids_filename.R")'`


------
https://chatgpt.com/codex/tasks/task_e_689414fea328832193e9cbbf6e925136