### PR TITLE
Fix nested_list_to_args quoting on Windows

### DIFF
--- a/R/cli_functions.R
+++ b/R/cli_functions.R
@@ -149,8 +149,10 @@ nested_list_to_args <- function(lst, sep = "/", collapse = FALSE) {
       if (is.list(val) && !is.null(names(val))) {
         args <- c(args, flatten(val, key))
       } else {
-        # quote argument with shQuote to prevent wildcard expansion and other oddities
-        val_str <- paste(shQuote(as.character(val)), collapse = " ")
+        # quote argument consistently across platforms (especially Windows)
+        # using single quotes via shQuote(..., type = "sh") to avoid wildcard
+        # expansion and other oddities
+        val_str <- paste(shQuote(as.character(val), type = "sh"), collapse = " ")
         args <- c(args, paste0("--", key, "=", val_str))
       }
     }


### PR DESCRIPTION
## Summary
- ensure `nested_list_to_args` uses consistent shell-style quoting on all platforms

## Testing
- `R -q -e "testthat::test_local()"` *(fails: dependencies `lgr`, `RNifti`, `signal` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68951557eefc832198b10feef419067a