### PR TITLE
Fix subject ID extraction for custom sub_id_match

### DIFF
--- a/R/run_project.R
+++ b/R/run_project.R
@@ -155,7 +155,14 @@ run_project <- function(scfg, steps = NULL, subject_filter = NULL, postprocess_s
   )
 
   if (isTRUE(steps["bids_conversion"])) {
-    subject_dicom_dirs <- get_subject_dirs(scfg$metadata$dicom_directory, sub_regex = scfg$bids_conversion$sub_regex, ses_regex = scfg$bids_conversion$ses_regex, full.names = TRUE)
+    subject_dicom_dirs <- get_subject_dirs(
+      scfg$metadata$dicom_directory,
+      sub_regex = scfg$bids_conversion$sub_regex,
+      sub_id_match = scfg$bids_conversion$sub_id_match,
+      ses_regex = scfg$bids_conversion$ses_regex,
+      ses_id_match = scfg$bids_conversion$ses_id_match,
+      full.names = TRUE
+    )
 
     if (nrow(subject_dicom_dirs) == 0L) {
       warning(glue("Cannot find any valid subject folders inside the DICOM directory: {scfg$metadata$dicom_directory}"))

--- a/tests/testthat/test-run_project-sub_id_match.R
+++ b/tests/testthat/test-run_project-sub_id_match.R
@@ -1,0 +1,61 @@
+test_that("run_project uses custom sub_id_match for dicom dirs", {
+  # Setup temporary directories
+  tmp <- tempfile("proj_")
+  dir.create(tmp)
+  dicom_dir <- file.path(tmp, "dicoms"); dir.create(dicom_dir)
+  bids_dir <- file.path(tmp, "bids"); dir.create(bids_dir)
+  fmriprep_dir <- file.path(tmp, "fmriprep"); dir.create(fmriprep_dir)
+  mriqc_dir <- file.path(tmp, "mriqc"); dir.create(mriqc_dir)
+  log_dir <- file.path(tmp, "logs"); dir.create(log_dir)
+
+  # Create a subject directory with letters and numbers
+  dir.create(file.path(dicom_dir, "SB1134"))
+
+  # Dummy files required by run_project
+  heuristic_file <- file.path(tmp, "heuristic.py"); file.create(heuristic_file)
+  container_file <- file.path(tmp, "heudiconv.sif"); file.create(container_file)
+
+  scfg <- list(
+    metadata = list(
+      project_name = "test",
+      project_directory = tmp,
+      dicom_directory = dicom_dir,
+      bids_directory = bids_dir,
+      fmriprep_directory = fmriprep_dir,
+      mriqc_directory = mriqc_dir,
+      log_directory = log_dir
+    ),
+    bids_conversion = list(
+      enable = TRUE,
+      sub_regex = "SBJ*[0-9]+",
+      sub_id_match = "(.+)",
+      ses_regex = NA_character_,
+      ses_id_match = NA_character_,
+      heuristic_file = heuristic_file
+    ),
+    compute_environment = list(
+      heudiconv_container = container_file,
+      scheduler = "sh"
+    )
+  )
+  class(scfg) <- "bg_project_cfg"
+
+  captured <- NULL
+  ns <- asNamespace("BrainGnomes")
+  orig <- get("process_subject", envir = ns)
+  unlockBinding("process_subject", ns)
+  assign("process_subject", function(scfg, sub_cfg, steps, postprocess_streams = NULL, parent_ids = NULL) {
+    captured <<- sub_cfg
+    TRUE
+  }, envir = ns)
+  lockBinding("process_subject", ns)
+  on.exit({
+    unlockBinding("process_subject", ns)
+    assign("process_subject", orig, envir = ns)
+    lockBinding("process_subject", ns)
+  })
+
+  run_project(scfg, steps = "bids_conversion", debug = TRUE)
+
+  expect_equal(captured$sub_id, "SB1134")
+})


### PR DESCRIPTION
## Summary
- ensure run_project forwards `sub_id_match` and `ses_id_match` to `get_subject_dirs`
- add regression test verifying subject IDs with prefixes are preserved

## Testing
- `R CMD INSTALL .` *(fails: dependencies 'lgr', 'RNifti', 'signal' are not available)*
- `R -q -e "testthat::test_dir('tests/testthat', reporter='summary')"` *(fails: package cannot be loaded due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689cefd1e9788321adb962ef052c4730