### PR TITLE
Handle NA columns in ROI correlations

### DIFF
--- a/tests/testthat/test-extract_rois.R
+++ b/tests/testthat/test-extract_rois.R
@@ -1,8 +1,12 @@
 test_that("extract_rois creates timeseries and correlations", {
   skip_if_not_installed("RNifti")
+  skip_if_not_installed("corpcor")
+  skip_if_not_installed("data.table")
+  skip_if_not_installed("lgr")
+  skip_if_not_installed("checkmate")
   library(RNifti)
   tmpdir <- tempdir()
-  arr <- array(rnorm(3*3*3*5), dim = c(3,3,3,5))
+  arr <- array(rnorm(3*3*3*25), dim = c(3,3,3,25))
   bold_file <- file.path(tmpdir, "sub-01_task-test_desc-test_bold.nii.gz")
   RNifti::writeNifti(RNifti::asNifti(arr), bold_file)
 
@@ -13,12 +17,13 @@ test_that("extract_rois creates timeseries and correlations", {
   RNifti::writeNifti(RNifti::asNifti(atlas_arr), atlas_file)
 
   res <- extract_rois(bold_file, atlas_files = atlas_file, out_dir = tmpdir,
-                      cor_method = "kendall", roi_reduce = "median")
+                      cor_method = "cor.shrink", roi_reduce = "median")
   atlas_name <- names(res)[1]
   ts_file <- res[[atlas_name]]$timeseries
-  corr_file <- res[[atlas_name]]$correlation[["kendall"]]
+  corr_file <- res[[atlas_name]]$correlation[["cor.shrink"]]
   expect_true(file.exists(ts_file))
   expect_true(file.exists(corr_file))
-  ts_df <- data.table::fread(ts_file)
-  expect_true("roi1" %in% names(ts_df))
+  cmat <- as.matrix(read.delim(corr_file, check.names = FALSE))
+  expect_equal(dim(cmat), c(2, 2))
+  expect_true(all(is.na(cmat[2, ])) && all(is.na(cmat[, 2])))
 })


### PR DESCRIPTION
## Summary
- Avoid cor.shrink failures by dropping NA ROI columns before correlation and reinstating them afterward
- Test extract_rois with cor.shrink ensuring NA ROIs yield correctly-sized matrices

## Testing
- `R -q -e "testthat::test_file('tests/testthat/test-extract_rois.R')"` *(fails: there is no package called 'testthat')*


------
https://chatgpt.com/codex/tasks/task_e_68b49ddaa4388321ad41240c48c51655