### PR TITLE
Add extract_rois vignette and quickstart section

### DIFF
--- a/vignettes/braingnomes_quickstart.Rmd
+++ b/vignettes/braingnomes_quickstart.Rmd
@@ -286,6 +286,15 @@ run_project(scfg, subject_filter=c("242", "510"), steps="postprocess")
 
 The available `steps` are `"bids_conversion", "mriqc", "fmriprep", "aroma", "postprocess"`. Note that if you request a step in `run_project` that was never configured it will result in an error.
 
+# Step 5: Extract ROI time series
+
+If ROI extraction was enabled during project setup, BrainGnomes can summarise
+atlas-defined regions and, optionally, compute ROI-to-ROI connectivity. The
+`extract_rois()` function loops over configured atlases and writes out ROI time
+series and correlation matrices to the project’s `data_rois` directory using
+BIDS-style filenames. For more details about ROI reduction choices and
+correlation options, see the [Extracting ROIs vignette](extract_rois.html).
+
 # Running BrainGnomes on the command line
 
 As of August 2025, this is a work in progress. That said, there is basic support for using BrainGnomes on the Linux command line. This is helpful if you prefer not to start an R session or you just want to perform basic operations such as

--- a/vignettes/extract_rois.Rmd
+++ b/vignettes/extract_rois.Rmd
@@ -1,0 +1,81 @@
+---
+title: "Extracting ROI Timeseries and Connectivity"
+author: "Michael Hallquist"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Extracting ROIs}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+# Overview
+
+The `extract_rois()` function summarises postprocessed BOLD data within
+atlas‑defined regions and can also compute ROI‑to‑ROI connectivity matrices.
+It is typically run after postprocessing completes and writes its outputs to
+the project’s `data_rois` directory.
+
+# Configuring extraction
+
+ROI extraction is enabled during `setup_project()` or `edit_project()`. Once
+configured, `run_project()` will schedule extraction jobs or you can call
+`extract_rois()` directly:
+
+```{r eval = FALSE}
+library(BrainGnomes)
+extract_rois(
+  bold_file = "sub-01_task-rest_desc-clean_bold.nii.gz",
+  atlas_files = "Schaefer400.nii.gz",
+  out_dir = "data_rois",
+  roi_reduce = "mean",
+  cor_method = c("pearson", "cor.shrink")
+)
+```
+
+# ROI reduction methods
+
+Each atlas region contains many voxels. The `roi_reduce` argument controls how
+those voxel time series are combined into a single ROI signal:
+
+* **mean** – averages all voxels (default).
+* **median** – takes the median to reduce sensitivity to outliers.
+* **pca** – extracts the first principal component and aligns its sign with the
+  mean, capturing the dominant pattern of variation.
+* **huber** – applies a Huber M‑estimator for a robust trimmed mean.
+
+# Choosing correlation methods
+
+Connectivity matrices are optional and are governed by the `cor_method`
+argument. Multiple methods may be supplied. Supported options include:
+
+* **pearson** – standard product–moment correlation.
+* **spearman** – rank‑based correlation that is robust to non‑linear but
+  monotonic relationships.
+* **kendall** – Kendall’s \tau for ordinal or small sample data.
+* **cor.shrink** – shrinkage estimator from the `corpcor` package, useful when
+  the number of ROIs is large relative to the number of time points.
+
+The `rtoz` flag applies Fisher’s \(z\) transform to correlations, producing
+unbounded values better suited for group analysis.
+
+# Output files and naming
+
+Outputs are organised by atlas within `data_rois/<atlas_name>/`.  Filenames use
+extended BIDS entities: the atlas appears as `rois-<Atlas>` and correlation
+methods are labelled `cor-<method>`. For example:
+
+```
+sub-01_task-rest_desc-clean_rois-Schaefer400_timeseries.tsv
+sub-01_task-rest_desc-clean_rois-Schaefer400_cor-pearson_connectivity.tsv
+```
+
+These naming conventions ensure that time‑series and connectivity files can be
+matched to their originating runs and analysis choices.
+
+# Summary
+
+`extract_rois()` provides a flexible way to derive ROI signals and functional
+connectivity from postprocessed fMRI data. By selecting appropriate reduction
+and correlation methods, you can tailor ROI analyses to the needs of your
+study.
+


### PR DESCRIPTION
## Summary
- document `extract_rois()` in the quickstart with BIDS-style output details
- add dedicated `extract_rois` vignette covering ROI reduction methods, correlation options, and naming conventions

## Testing
- `rmarkdown::render('vignettes/extract_rois.Rmd', output_dir='vignettes', envir=new.env())`
- `R CMD build .` *(fails: dependencies ‘corpcor’, ‘lgr’, ‘RNifti’, ‘signal’ are not available)*
- `devtools::test()` *(fails: dependencies ‘corpcor’, ‘lgr’, ‘RNifti’, ‘signal’ are not available)*

------
https://chatgpt.com/codex/tasks/task_e_68b49ed7208c83219f38effdd9767b7f