### PR TITLE
Verify directory before saving project configuration

### DIFF
--- a/man/save_project_config.Rd
+++ b/man/save_project_config.Rd
@@ -17,8 +17,9 @@ Invisibly returns \code{scfg}.
 }
 \description{
 Writes the configuration to a file named \code{project_config.yaml} inside
-the project's root directory. If a configuration file already exists,
-the user is shown a summary of differences and asked whether to
-overwrite the file.
+the project's root directory. The function checks that the destination
+directory exists, offering to create it or to save to an alternate
+location. If a configuration file already exists, the user is shown a
+summary of differences and asked whether to overwrite the file.
 }
 \keyword{internal}


### PR DESCRIPTION
## Summary
- ensure `save_project_config()` checks the target directory exists
- prompt to create missing directories or choose an alternate location before saving

## Testing
- ⚠️ `R -q -e "devtools::document()"` *(missing devtools package)*
- ⚠️ `R -q -e "testthat::test_dir('tests/testthat')"` *(missing testthat package)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a524dd7883218388a48b655a41a5