### PR TITLE
feat: allow external BIDS directory

### DIFF
--- a/R/setup_project.R
+++ b/R/setup_project.R
@@ -119,6 +119,7 @@ setup_project_metadata <- function(scfg = NULL, fields = NULL) {
     if (is.null(scfg$metadata$project_name)) fields <- c(fields, "metadata/project_name")
     if (is.null(scfg$metadata$project_directory)) fields <- c(fields, "metadata/project_directory")
     # if (is.null(scfg$metadata$dicom_directory)) fields <- c(fields, "metadata/dicom_directory") # defer to setup_bids_conversion
+    if (is.null(scfg$metadata$bids_directory)) fields <- c(fields, "metadata/bids_directory")
     if (is.null(scfg$metadata$templateflow_home)) fields <- c(fields, "metadata/templateflow_home")
     if (is.null(scfg$metadata$scratch_directory)) fields <- c(fields, "metadata/scratch_directory")
   }
@@ -151,13 +152,23 @@ setup_project_metadata <- function(scfg = NULL, fields = NULL) {
   }
 
 
-  # location of BIDS data -- enforce that this must be within the project directory with a fixed name
-  scfg$metadata$bids_directory <- file.path(scfg$metadata$project_directory, "data_bids")
+  # location of BIDS data -- default within project directory, but allow external paths
+  if ("metadata/bids_directory" %in% fields) {
+    scfg$metadata$bids_directory <- prompt_input(
+      "Where is your BIDS directory located?",
+      type = "character",
+      default = file.path(scfg$metadata$project_directory, "data_bids")
+    )
+  } else if (is.null(scfg$metadata$bids_directory)) {
+    scfg$metadata$bids_directory <- file.path(scfg$metadata$project_directory, "data_bids")
+  }
+
   if (!checkmate::test_directory_exists(scfg$metadata$bids_directory)) {
-    # default to creating the directory
-    # create <- prompt_input(instruct = glue("The directory {scfg$metadata$bids_directory} does not exist. Would you like me to create it?\n"), type = "flag")
-    create <- TRUE
-    if (create) dir.create(scfg$metadata$bids_directory, recursive = TRUE) # should probably force this to happen
+    create <- prompt_input(
+      instruct = glue("The directory {scfg$metadata$bids_directory} does not exist. Would you like me to create it?\n"),
+      type = "flag"
+    )
+    if (create) dir.create(scfg$metadata$bids_directory, recursive = TRUE)
   }
 
   if ("metadata/scratch_directory" %in% fields) {

--- a/R/validate_project.R
+++ b/R/validate_project.R
@@ -140,7 +140,8 @@ validate_project <- function(scfg = list(), quiet = FALSE) {
   # required directories not tied to a specific step
   core_dirs <- c(
     "metadata/project_directory", "metadata/log_directory",
-    "metadata/scratch_directory", "metadata/templateflow_home"
+    "metadata/bids_directory", "metadata/scratch_directory",
+    "metadata/templateflow_home"
   )
   for (rr in core_dirs) {
     if (!checkmate::test_directory_exists(get_nested_values(scfg, rr))) {

--- a/tests/testthat/test-run_project-sub_id_match.R
+++ b/tests/testthat/test-run_project-sub_id_match.R
@@ -3,7 +3,7 @@ test_that("run_project uses custom sub_id_match for dicom dirs", {
   tmp <- tempfile("proj_")
   dir.create(tmp)
   dicom_dir <- file.path(tmp, "dicoms"); dir.create(dicom_dir)
-  bids_dir <- file.path(tmp, "bids"); dir.create(bids_dir)
+  bids_dir <- tempfile("bids_"); dir.create(bids_dir)
   fmriprep_dir <- file.path(tmp, "fmriprep"); dir.create(fmriprep_dir)
   mriqc_dir <- file.path(tmp, "mriqc"); dir.create(mriqc_dir)
   log_dir <- file.path(tmp, "logs"); dir.create(log_dir)

--- a/tests/testthat/test-submit_fmriprep-bids.R
+++ b/tests/testthat/test-submit_fmriprep-bids.R
@@ -1,0 +1,68 @@
+test_that("submit_fmriprep binds external BIDS directory", {
+  proj_dir <- tempfile("proj_")
+  dir.create(proj_dir)
+  bids_dir <- tempfile("bids_")
+  dir.create(file.path(bids_dir, "sub-01"), recursive = TRUE)
+  fmriprep_dir <- file.path(proj_dir, "fmriprep")
+  dir.create(fmriprep_dir)
+  scratch_dir <- file.path(proj_dir, "scratch")
+  dir.create(scratch_dir)
+  templateflow <- file.path(proj_dir, "templateflow")
+  dir.create(templateflow)
+  log_dir <- file.path(proj_dir, "logs")
+  dir.create(log_dir)
+  fs_license <- file.path(proj_dir, "fs_license.txt")
+  file.create(fs_license)
+  container_file <- file.path(proj_dir, "fmriprep.sif")
+  file.create(container_file)
+  sched_script <- file.path(proj_dir, "fmriprep_subject.sbatch")
+  file.create(sched_script)
+
+  scfg <- list(
+    metadata = list(
+      project_directory = proj_dir,
+      bids_directory = bids_dir,
+      fmriprep_directory = fmriprep_dir,
+      scratch_directory = scratch_dir,
+      templateflow_home = templateflow,
+      log_directory = log_dir
+    ),
+    compute_environment = list(
+      fmriprep_container = container_file,
+      scheduler = "sh"
+    ),
+    fmriprep = list(
+      enable = TRUE,
+      memgb = 4,
+      nhours = 1,
+      ncores = 1,
+      cli_options = "",
+      sched_args = "",
+      output_spaces = "MNI152NLin2009cAsym",
+      fs_license_file = fs_license
+    )
+  )
+  class(scfg) <- "bg_project_cfg"
+
+  captured <- NULL
+  ns <- asNamespace("BrainGnomes")
+  orig <- get("cluster_job_submit", envir = ns)
+  unlockBinding("cluster_job_submit", ns)
+  assign("cluster_job_submit", function(sched_script, scheduler, sched_args, env_variables, wait_jobs, echo) {
+    captured <<- env_variables
+    structure("1", cmd = "cmd")
+  }, envir = ns)
+  lockBinding("cluster_job_submit", ns)
+  on.exit({
+    unlockBinding("cluster_job_submit", ns)
+    assign("cluster_job_submit", orig, envir = ns)
+    lockBinding("cluster_job_submit", ns)
+  })
+
+  submit_fmriprep(scfg, sub_dir = file.path(bids_dir, "sub-01"), sub_id = "01",
+                  env_variables = NULL, sched_script = sched_script, sched_args = NULL,
+                  parent_ids = NULL, lg = lgr::get_logger("test"))
+
+  expect_equal(captured[["loc_bids_root"]], bids_dir)
+  expect_equal(captured[["loc_mrproc_root"]], fmriprep_dir)
+})


### PR DESCRIPTION
## Summary
- allow configuration of a BIDS directory outside the project directory
- validate the BIDS directory regardless of location
- test fmriprep submission with external BIDS root

## Testing
- `R -q -e "for(f in list.files('R', full.names=TRUE)) source(f); testthat::test_dir('tests/testthat')"` *(fails: package 'lgr' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a347cc74832186cf7ca7ead7ffc1