### PR TITLE
Handle external fMRIPrep directories during postprocessing

### DIFF
--- a/R/path_utils.R
+++ b/R/path_utils.R
@@ -1,0 +1,16 @@
+#' Determine if a path lies outside the project directory
+#'
+#' @param path The path to evaluate.
+#' @param project_dir The root project directory.
+#' @return `TRUE` if `path` is not within `project_dir`, otherwise `FALSE`.
+#' @keywords internal
+is_external_path <- function(path, project_dir) {
+  checkmate::assert_string(path)
+  checkmate::assert_string(project_dir)
+  path_norm <- normalizePath(path, winslash = "/", mustWork = FALSE)
+  proj_norm <- normalizePath(project_dir, winslash = "/", mustWork = FALSE)
+  path_norm <- sub("/+$", "", path_norm)
+  proj_norm <- sub("/+$", "", proj_norm)
+  inside <- startsWith(path_norm, paste0(proj_norm, "/")) || path_norm == proj_norm
+  !inside
+}

--- a/tests/testthat/test-fmriprep-directory.R
+++ b/tests/testthat/test-fmriprep-directory.R
@@ -1,0 +1,78 @@
+test_that("is_external_path identifies directories", {
+  proj <- tempfile("proj_")
+  dir.create(proj)
+  inside <- file.path(proj, "data_fmriprep")
+  outside <- tempfile("fmriprep_")
+  expect_false(BrainGnomes:::is_external_path(inside, proj))
+  expect_true(BrainGnomes:::is_external_path(outside, proj))
+})
+
+test_that("process_subject checks complete file for internal fmriprep", {
+  root <- tempdir()
+  proj_dir <- file.path(root, "proj_int"); dir.create(proj_dir)
+  log_dir <- file.path(proj_dir, "logs"); dir.create(log_dir)
+  bids_dir <- file.path(proj_dir, "bids"); dir.create(bids_dir)
+  fmriprep_dir <- file.path(proj_dir, "data_fmriprep"); dir.create(file.path(fmriprep_dir, "sub-01"), recursive = TRUE)
+  scfg <- list(
+    metadata = list(project_directory = proj_dir, log_directory = log_dir,
+                    bids_directory = bids_dir, fmriprep_directory = fmriprep_dir),
+    postprocess = list(enable = TRUE),
+    fmriprep = list(enable = FALSE),
+    compute_environment = list(scheduler = "slurm"),
+    force = FALSE
+  )
+  class(scfg) <- "bg_project_cfg"
+  sub_cfg <- data.frame(sub_id = "01", ses_id = NA_character_, dicom_sub_dir = NA_character_,
+                        dicom_ses_dir = NA_character_, bids_sub_dir = file.path(bids_dir, "sub-01"),
+                        bids_ses_dir = NA_character_, stringsAsFactors = FALSE)
+  is_called <- FALSE
+  ns <- asNamespace("BrainGnomes")
+  orig <- get("is_step_complete", envir = ns)
+  unlockBinding("is_step_complete", ns)
+  assign("is_step_complete", function(...) {is_called <<- TRUE; orig(...)}, envir = ns)
+  lockBinding("is_step_complete", ns)
+  on.exit({
+    unlockBinding("is_step_complete", ns)
+    assign("is_step_complete", orig, envir = ns)
+    lockBinding("is_step_complete", ns)
+  })
+  steps <- c(bids_conversion = FALSE, mriqc = FALSE, fmriprep = FALSE, aroma = FALSE,
+             postprocess = TRUE, extract_rois = FALSE)
+  process_subject(scfg, sub_cfg, steps)
+  expect_true(is_called)
+})
+
+test_that("process_subject accepts external fmriprep without complete file", {
+  root <- tempdir()
+  proj_dir <- file.path(root, "proj_ext"); dir.create(proj_dir)
+  log_dir <- file.path(proj_dir, "logs"); dir.create(log_dir)
+  bids_dir <- file.path(proj_dir, "bids"); dir.create(bids_dir)
+  fmriprep_dir <- file.path(root, "external_fmriprep"); dir.create(file.path(fmriprep_dir, "sub-01"), recursive = TRUE)
+  scfg <- list(
+    metadata = list(project_directory = proj_dir, log_directory = log_dir,
+                    bids_directory = bids_dir, fmriprep_directory = fmriprep_dir),
+    postprocess = list(enable = TRUE),
+    fmriprep = list(enable = FALSE),
+    compute_environment = list(scheduler = "slurm"),
+    force = FALSE
+  )
+  class(scfg) <- "bg_project_cfg"
+  sub_cfg <- data.frame(sub_id = "01", ses_id = NA_character_, dicom_sub_dir = NA_character_,
+                        dicom_ses_dir = NA_character_, bids_sub_dir = file.path(bids_dir, "sub-01"),
+                        bids_ses_dir = NA_character_, stringsAsFactors = FALSE)
+  is_called <- FALSE
+  ns <- asNamespace("BrainGnomes")
+  orig <- get("is_step_complete", envir = ns)
+  unlockBinding("is_step_complete", ns)
+  assign("is_step_complete", function(...) {is_called <<- TRUE; orig(...)}, envir = ns)
+  lockBinding("is_step_complete", ns)
+  on.exit({
+    unlockBinding("is_step_complete", ns)
+    assign("is_step_complete", orig, envir = ns)
+    lockBinding("is_step_complete", ns)
+  }, add = TRUE)
+  steps <- c(bids_conversion = FALSE, mriqc = FALSE, fmriprep = FALSE, aroma = FALSE,
+             postprocess = TRUE, extract_rois = FALSE)
+  process_subject(scfg, sub_cfg, steps)
+  expect_false(is_called)
+})


### PR DESCRIPTION
## Summary
- add `is_external_path` helper to detect paths outside the project
- relax `.complete` file requirement for external fMRIPrep directories
- cover internal vs. external fMRIPrep directories with new tests

## Testing
- `R -q -e 'install.packages(c("roxygen2","testthat"), repos="https://cloud.r-project.org")'` (failed: packages not available)
- `R -q -e 'testthat::test_dir("tests/testthat")'` (failed: package 'testthat' not installed)


------
https://chatgpt.com/codex/tasks/task_e_68b711dd04dc83219222dcbd8a1a8ab2