### PR TITLE
Add postprocessing directory metadata and update pipeline

### DIFF
--- a/R/pipeline_functions.R
+++ b/R/pipeline_functions.R
@@ -248,10 +248,10 @@ is_step_complete <- function(scfg, sub_id, ses_id = NULL,
         file.path(scfg$metadata$fmriprep_directory, glue("sub-{sub_id}"))
       },
     postprocess = if (!is.null(ses_id)) {
-        file.path(scfg$metadata$fmriprep_directory, glue("sub-{sub_id}"),
+        file.path(scfg$metadata$postproc_directory, glue("sub-{sub_id}"),
                   glue("ses-{ses_id}"))
       } else {
-        file.path(scfg$metadata$fmriprep_directory, glue("sub-{sub_id}"))
+        file.path(scfg$metadata$postproc_directory, glue("sub-{sub_id}"))
       }
   )
 

--- a/R/process_subject.R
+++ b/R/process_subject.R
@@ -459,7 +459,7 @@ submit_postprocess <- function(
 
   env_variables <- c(
     env_variables,
-    loc_mrproc_root = scfg$metadata$fmriprep_directory,
+    loc_postproc_root = scfg$metadata$postproc_directory,
     sub_id = sub_id,
     ses_id = ses_id,
     postprocess_cli = postprocess_cli,
@@ -493,7 +493,7 @@ submit_extract_rois <- function(
   extract_rscript <- system.file("extract_cli.R", package = "BrainGnomes")
   extract_sched_script <- get_job_script(scfg, "extract_rois")
 
-  input_dir <- file.path(scfg$metadata$fmriprep_directory, glue("sub-{sub_id}")) # populate the location of this sub/ses dir into the config to pass on as CLI
+  input_dir <- file.path(scfg$metadata$postproc_directory, glue("sub-{sub_id}")) # populate the location of this sub/ses dir into the config to pass on as CLI
   if (!is.null(ses_id) && !is.na(ses_id)) input_dir <- file.path(input_dir, glue("ses-{ses_id}")) # add session subdir if relevant
 
   # pull the requested extraction stream from the broader list
@@ -515,7 +515,7 @@ submit_extract_rois <- function(
 
   env_variables <- c(
     env_variables,
-    loc_mrproc_root = scfg$metadata$fmriprep_directory,
+    loc_postproc_root = scfg$metadata$postproc_directory,
     sub_id = sub_id,
     ses_id = ses_id,
     extract_cli = extract_cli,

--- a/R/run_project.R
+++ b/R/run_project.R
@@ -27,7 +27,7 @@
 #'     run_project(study_config, prompt = TRUE, force = FALSE)
 #'   }
 #' @importFrom glue glue
-#' @importFrom checkmate assert_list assert_flag assert_directory_exists
+#' @importFrom checkmate assert_list assert_flag
 #' @importFrom lgr get_logger_glue
 run_project <- function(scfg, steps = NULL, subject_filter = NULL, postprocess_streams = NULL, 
   extract_streams = NULL, debug = FALSE, force = FALSE) {
@@ -60,7 +60,8 @@ run_project <- function(scfg, steps = NULL, subject_filter = NULL, postprocess_s
       Project directory:   {pretty_arg(scfg$metadata$project_directory)}
       DICOM directory:     {pretty_arg(scfg$metadata$dicom_directory)}
       BIDS directory:      {pretty_arg(scfg$metadata$bids_directory)}
-      fmriprep directory:  {pretty_arg(scfg$metadata$fmriprep_directory)}\n
+      fmriprep directory:  {pretty_arg(scfg$metadata$fmriprep_directory)}
+      Postprocess directory: {pretty_arg(scfg$metadata$postproc_directory)}\n
       "))
 
   # by passing steps, user is asking for unattended execution

--- a/R/setup_project.R
+++ b/R/setup_project.R
@@ -184,6 +184,9 @@ setup_project_metadata <- function(scfg = NULL, fields = NULL) {
   # location for ROI timeseries and connectivity data
   scfg$metadata$roi_directory <- file.path(scfg$metadata$project_directory, "data_rois")
 
+  # location for postprocessed data
+  scfg$metadata$postproc_directory <- file.path(scfg$metadata$project_directory, "data_postproc")
+
   return(scfg)
 }
 

--- a/R/setup_project_directories.R
+++ b/R/setup_project_directories.R
@@ -17,6 +17,7 @@ setup_project_directories <- function(scfg) {
     scfg$metadata$bids_directory,
     scfg$metadata$log_directory,
     scfg$metadata$roi_directory,
+    scfg$metadata$postproc_directory,
     scfg$metadata$fmriprep_directory,
     scfg$metadata$mriqc_directory,
     scfg$metadata$scratch_directory,

--- a/R/validate_project.R
+++ b/R/validate_project.R
@@ -158,6 +158,13 @@ validate_project <- function(scfg = list(), quiet = FALSE) {
     }
   }
 
+  if (any(scfg$postprocess$enable, scfg$extract_rois$enable, na.rm = TRUE)) {
+    if (!checkmate::test_directory_exists(get_nested_values(scfg, "metadata/postproc_directory"))) {
+      message("Config file is missing valid directory for metadata/postproc_directory.")
+      gaps <- c(gaps, "metadata/postproc_directory")
+    }
+  }
+
   if (isTRUE(scfg$mriqc$enable)) {
     if (!checkmate::test_directory_exists(get_nested_values(scfg, "metadata/mriqc_directory"))) {
       message("Config file is missing valid directory for metadata/mriqc_directory.")

--- a/inst/hpc_scripts/extract_rois_subject.sbatch
+++ b/inst/hpc_scripts/extract_rois_subject.sbatch
@@ -24,8 +24,8 @@ ncores=$SLURM_NTASKS
 
 ####
 #verify required arguments
-[ -z "$loc_mrproc_root" ] && echo "loc_mrproc_root not set. Exiting." && exit 1
-[ ! -r "$loc_mrproc_root" ] && echo "loc_mrproc_root $loc_mrproc_root not readable. Exiting" && exit 1
+[ -z "$loc_postproc_root" ] && echo "loc_postproc_root not set. Exiting." && exit 1
+[ ! -r "$loc_postproc_root" ] && echo "loc_postproc_root $loc_postproc_root not readable. Exiting" && exit 1
 [ -z "$sub_id" ] && echo "sub_id not set. Exiting." && exit 1
 [ -z "$extract_cli" ] && echo "extract_cli not set. Exiting." && exit 1
 [ -z "$extract_rscript" ] && echo "extract_rscript not set. Exiting." && exit 1
@@ -43,10 +43,10 @@ stderr_log="${stderr_log//%j/$SLURM_JOB_ID}"
 ###
 # handle multi-session setup
 if [ -n "$ses_id" ]; then
-  out_dir=${loc_mrproc_root}/sub-${sub_id}/ses-${ses_id}
+  out_dir=${loc_postproc_root}/sub-${sub_id}/ses-${ses_id}
   ses_str="session $ses_id"
 else
-  out_dir=${loc_mrproc_root}/sub-${sub_id}
+  out_dir=${loc_postproc_root}/sub-${sub_id}
   ses_str=""
 fi
 mkdir -p "$out_dir"

--- a/inst/hpc_scripts/postprocess_image_subject.sbatch
+++ b/inst/hpc_scripts/postprocess_image_subject.sbatch
@@ -27,8 +27,8 @@ ncores=$SLURM_NTASKS
 
 ####
 #verify required arguments
-[ -z "$loc_mrproc_root" ] && echo "loc_mrproc_root not set. Exiting." && exit 1
-[ ! -r "$loc_mrproc_root" ] && echo "loc_mrproc_root $loc_mrproc_root not readable. Exiting" && exit 1
+[ -z "$loc_postproc_root" ] && echo "loc_postproc_root not set. Exiting." && exit 1
+[ ! -r "$loc_postproc_root" ] && echo "loc_postproc_root $loc_postproc_root not readable. Exiting" && exit 1
 [ -z "$sub_id" ] && echo "sub_id not set. Exiting." && exit 1
 [ -z "$postprocess_cli" ] && echo "postprocess_cli not set. Exiting." && exit 1
 [ -z "$postprocess_rscript" ] && echo "postprocess_rscript not set. Exiting." && exit 1
@@ -49,10 +49,10 @@ stderr_log="${stderr_log//%j/$SLURM_JOB_ID}"
 ###
 # handle multi-session setup
 if [ -n "$ses_id" ]; then
-  out_dir=${loc_mrproc_root}/sub-${sub_id}/ses-${ses_id}
+  out_dir=${loc_postproc_root}/sub-${sub_id}/ses-${ses_id}
   ses_str="session $ses_id"
 else
-  out_dir=${loc_mrproc_root}/sub-${sub_id}
+  out_dir=${loc_postproc_root}/sub-${sub_id}
   ses_str=""
 fi
 mkdir -p "$out_dir"

--- a/inst/hpc_scripts/postprocess_subject.sbatch
+++ b/inst/hpc_scripts/postprocess_subject.sbatch
@@ -25,8 +25,8 @@ ncores=$SLURM_NTASKS
 
 ####
 #verify required arguments
-[ -z "$loc_mrproc_root" ] && echo "loc_mrproc_root not set. Exiting." && exit 1
-[ ! -r "$loc_mrproc_root" ] && echo "loc_mrproc_root $loc_mrproc_root not readable. Exiting" && exit 1
+[ -z "$loc_postproc_root" ] && echo "loc_postproc_root not set. Exiting." && exit 1
+[ ! -r "$loc_postproc_root" ] && echo "loc_postproc_root $loc_postproc_root not readable. Exiting" && exit 1
 [ -z "$sub_id" ] && echo "sub_id not set. Exiting." && exit 1
 [ -z "$complete_file" ] && echo "complete_file not set. Exiting." && exit 1
 [ -z "$postprocess_cli" ] && echo "postprocess_cli not set. Exiting." && exit 1
@@ -60,10 +60,10 @@ stderr_log="${stderr_log//%j/$SLURM_JOB_ID}"
 ###
 # handle multi-session setup
 if [ -n "$ses_id" ]; then
-  out_dir=${loc_mrproc_root}/sub-${sub_id}/ses-${ses_id}
+  out_dir=${loc_postproc_root}/sub-${sub_id}/ses-${ses_id}
   ses_str="session $ses_id"
 else
-  out_dir=${loc_mrproc_root}/sub-${sub_id}
+  out_dir=${loc_postproc_root}/sub-${sub_id}
   ses_str=""
 fi
 mkdir -p "$out_dir"

--- a/tests/example_config.yaml
+++ b/tests/example_config.yaml
@@ -4,6 +4,7 @@ metadata:
   dicom_directory: /proj/mnhallqlab/projects/preproc_pipeline_test_data/dicoms
   bids_directory: /proj/mnhallqlab/projects/preproc_pipeline_test_data/data_bids
   fmriprep_directory: /proj/mnhallqlab/projects/preproc_pipeline_test_data/data_fmriprep
+  postproc_directory: /proj/mnhallqlab/projects/preproc_pipeline_test_data/data_postproc
   mriqc_directory: /proj/mnhallqlab/projects/preproc_pipeline_test_data/mriqc_reports
   scratch_directory: /work/users/m/n/mnhallq
   templateflow_home: /nas/longleaf/home/mnhallq/.cache/templateflow

--- a/tests/testthat/test-run_project-sub_id_match.R
+++ b/tests/testthat/test-run_project-sub_id_match.R
@@ -5,6 +5,7 @@ test_that("run_project uses custom sub_id_match for dicom dirs", {
   dicom_dir <- file.path(tmp, "dicoms"); dir.create(dicom_dir)
   bids_dir <- tempfile("bids_"); dir.create(bids_dir)
   fmriprep_dir <- file.path(tmp, "fmriprep"); dir.create(fmriprep_dir)
+  postproc_dir <- file.path(tmp, "postproc"); dir.create(postproc_dir)
   mriqc_dir <- file.path(tmp, "mriqc"); dir.create(mriqc_dir)
   log_dir <- file.path(tmp, "logs"); dir.create(log_dir)
 
@@ -22,6 +23,7 @@ test_that("run_project uses custom sub_id_match for dicom dirs", {
       dicom_directory = dicom_dir,
       bids_directory = bids_dir,
       fmriprep_directory = fmriprep_dir,
+      postproc_directory = postproc_dir,
       mriqc_directory = mriqc_dir,
       log_directory = log_dir
     ),

--- a/tests/testthat/test-status_functions.R
+++ b/tests/testthat/test-status_functions.R
@@ -3,6 +3,7 @@ test_that("get_project_status reports completion", {
   log_dir <- file.path(root, "logs"); dir.create(log_dir)
   bids_dir <- file.path(root, "bids"); dir.create(bids_dir)
   fmriprep_dir <- file.path(root, "fmriprep"); dir.create(fmriprep_dir)
+  postproc_dir <- file.path(root, "postproc"); dir.create(postproc_dir)
   mriqc_dir <- file.path(root, "mriqc"); dir.create(mriqc_dir)
 
 
@@ -12,13 +13,15 @@ test_that("get_project_status reports completion", {
   dir.create(file.path(bids_dir, paste0("sub-", sub), paste0("ses-", ses_b)), recursive = TRUE)
   dir.create(file.path(fmriprep_dir, paste0("sub-", sub)), recursive = TRUE)
   dir.create(file.path(fmriprep_dir, paste0("sub-", sub), paste0("ses-", ses_a)), recursive = TRUE)
+  dir.create(file.path(postproc_dir, paste0("sub-", sub)), recursive = TRUE)
+  dir.create(file.path(postproc_dir, paste0("sub-", sub), paste0("ses-", ses_a)), recursive = TRUE)
 
   cat("2024-05-04 10:00:00", file = file.path(log_dir, paste0("sub-", sub), paste0(".bids_conversion_sub-", sub, "_ses-", ses_a, "_complete")))
   cat("2024-05-04 11:00:00", file = file.path(log_dir, paste0("sub-", sub), paste0(".fmriprep_sub-", sub, "_complete")))
   cat("2024-05-04 12:00:00", file = file.path(log_dir, paste0("sub-", sub), paste0(".postprocess_stream1_sub-", sub, "_ses-", ses_a, "_complete")))
 
   scfg <- list(
-    metadata = list(log_directory = log_dir, bids_directory = bids_dir, fmriprep_directory = fmriprep_dir, mriqc_directory = mriqc_dir),
+    metadata = list(log_directory = log_dir, bids_directory = bids_dir, fmriprep_directory = fmriprep_dir, mriqc_directory = mriqc_dir, postproc_directory = postproc_dir),
     bids_conversion = list(enable = TRUE),
     mriqc = list(enable = FALSE),
     fmriprep = list(enable = TRUE),


### PR DESCRIPTION
## Summary
- add `metadata$postproc_directory` with default `data_postproc`
- use new `loc_postproc_root` in postprocessing and extraction scripts
- display and validate postprocessing directory in project helpers
- allow `run_project()` to run without a pre-existing postproc directory

## Testing
- `apt-get install -y r-base`
- `R -q -e "install.packages(c('corpcor','lgr','RNifti','signal'), repos='https://cloud.r-project.org')"` *(fails: packages are not available for this version of R)*
- `R -q -e "devtools::document()"` *(fails: there is no package called 'devtools')*
- `R -q -e "devtools::test()"` *(fails: there is no package called 'devtools')*


------
https://chatgpt.com/codex/tasks/task_e_68b711c2ef60832191a9c77ba55bcd4c