### PR TITLE
feat: allow specifying postprocess output directory

### DIFF
--- a/inst/hpc_scripts/postprocess_image_subject.sbatch
+++ b/inst/hpc_scripts/postprocess_image_subject.sbatch
@@ -27,8 +27,7 @@ ncores=$SLURM_NTASKS
 
 ####
 #verify required arguments
-[ -z "$loc_postproc_root" ] && echo "loc_postproc_root not set. Exiting." && exit 1
-[ ! -r "$loc_postproc_root" ] && echo "loc_postproc_root $loc_postproc_root not readable. Exiting" && exit 1
+[ -z "$out_dir" ] && echo "out_dir not set. Exiting." && exit 1
 [ -z "$sub_id" ] && echo "sub_id not set. Exiting." && exit 1
 [ -z "$postprocess_cli" ] && echo "postprocess_cli not set. Exiting." && exit 1
 [ -z "$postprocess_rscript" ] && echo "postprocess_rscript not set. Exiting." && exit 1
@@ -46,17 +45,8 @@ ncores=$SLURM_NTASKS
 stdout_log="${stdout_log//%j/$SLURM_JOB_ID}"
 stderr_log="${stderr_log//%j/$SLURM_JOB_ID}"
 
-###
-# handle multi-session setup
-if [ -n "$ses_id" ]; then
-  out_dir=${loc_postproc_root}/sub-${sub_id}/ses-${ses_id}
-  ses_str="session $ses_id"
-else
-  out_dir=${loc_postproc_root}/sub-${sub_id}
-  ses_str=""
-fi
 mkdir -p "$out_dir"
-cd $out_dir || { echo "Failed to change directory to $out_dir"; exit 1; }
+cd "$out_dir" || { echo "Failed to change directory to $out_dir"; exit 1; }
 
 ####
 if [[ "$debug_pipeline" == "TRUE" || "$debug_pipeline" -eq 1 ]]; then

--- a/inst/hpc_scripts/postprocess_subject.sbatch
+++ b/inst/hpc_scripts/postprocess_subject.sbatch
@@ -25,8 +25,7 @@ ncores=$SLURM_NTASKS
 
 ####
 #verify required arguments
-[ -z "$loc_postproc_root" ] && echo "loc_postproc_root not set. Exiting." && exit 1
-[ ! -r "$loc_postproc_root" ] && echo "loc_postproc_root $loc_postproc_root not readable. Exiting" && exit 1
+[ -z "$out_dir" ] && echo "out_dir not set. Exiting." && exit 1
 [ -z "$sub_id" ] && echo "sub_id not set. Exiting." && exit 1
 [ -z "$complete_file" ] && echo "complete_file not set. Exiting." && exit 1
 [ -z "$postprocess_cli" ] && echo "postprocess_cli not set. Exiting." && exit 1
@@ -57,17 +56,14 @@ fi
 stdout_log="${stdout_log//%j/$SLURM_JOB_ID}"
 stderr_log="${stderr_log//%j/$SLURM_JOB_ID}"
 
-###
-# handle multi-session setup
+
+ses_str=""
 if [ -n "$ses_id" ]; then
-  out_dir=${loc_postproc_root}/sub-${sub_id}/ses-${ses_id}
   ses_str="session $ses_id"
-else
-  out_dir=${loc_postproc_root}/sub-${sub_id}
-  ses_str=""
 fi
 mkdir -p "$out_dir"
-cd $out_dir || { echo "Failed to change directory to $out_dir"; exit 1; }
+cd "$out_dir" || { echo "Failed to change directory to $out_dir"; exit 1; }
+export out_dir
 
 ####
 log_flag=""

--- a/inst/postprocess_cli.R
+++ b/inst/postprocess_cli.R
@@ -13,7 +13,7 @@ if (length(argpos) > 0L) {
 }
 
 if (is.null(args) || length(args) < 2L) {
-  message("Minimal usage: postprocess_cli.R --input=<input_file> --config_yaml=<config_yaml.yaml> [--fsl_img=<fsl_singularity_image>]")
+  message("Minimal usage: postprocess_cli.R --input=<input_file> --config_yaml=<config_yaml.yaml> [--output_dir=<output_dir>] [--fsl_img=<fsl_singularity_image>]")
   quit(save="no", 1, FALSE)
 }
 


### PR DESCRIPTION
## Summary
- add `--output_dir` flag to `postprocess_cli`
- ensure postprocessing functions write outputs to supplied directory
- update HPC postprocess scripts to use provided output paths
- symlink input BOLD files into output directory to avoid redundant copies

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found: R)*
- `R -q -e 'if (requireNamespace("testthat", quietly=TRUE)) testthat::test_dir("tests/testthat") else message("testthat not installed")'` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68b73c6f63f88321927cb963b0c94b30