### PR TITLE
refactor postprocess output file handling

### DIFF
--- a/R/postprocess_confounds.R
+++ b/R/postprocess_confounds.R
@@ -81,7 +81,7 @@ postprocess_confounds <- function(proc_files, cfg, processing_sequence,
   # Regress out AROMA components, if requested (overwrites file in place)
   if ("apply_aroma" %in% processing_sequence) {
     lg$info("Removing AROMA noise components from confounds")
-    confound_nii <- apply_aroma(confound_nii, out_desc = cfg$bids_desc,
+    confound_nii <- apply_aroma(confound_nii, out_file = confound_nii,
       mixing_file = proc_files$melodic_mix, noise_ics = proc_files$noise_ics,
       overwrite = TRUE, lg = lg, use_R = TRUE, fsl_img = fsl_img
     )
@@ -91,7 +91,8 @@ postprocess_confounds <- function(proc_files, cfg, processing_sequence,
   if ("temporal_filter" %in% processing_sequence) {
     lg$info("Temporally filtering confounds")
     confound_nii <- temporal_filter(confound_nii,
-      tr = cfg$tr, out_desc = cfg$bids_desc,
+      out_file = confound_nii,
+      tr = cfg$tr,
       low_pass_hz = cfg$temporal_filter$low_pass_hz,
       high_pass_hz = cfg$temporal_filter$high_pass_hz,
       overwrite = TRUE, lg = lg, fsl_img = fsl_img,

--- a/tests/testthat/test-scrub_timepoints.R
+++ b/tests/testthat/test-scrub_timepoints.R
@@ -17,7 +17,8 @@ test_that("scrub_timepoints removes timepoints and updates confounds", {
 
   out <- scrub_timepoints(infile, censor_file,
                           confound_files = conf_file,
-                          out_desc = "scrub", lg = lgr::get_logger_glue("BrainGnomes"))
+                          out_file = tempfile(fileext = ".nii.gz"),
+                          lg = lgr::get_logger_glue("BrainGnomes"))
 
   res <- RNifti::readNifti(out)
   expect_equal(dim(res)[4], 3)
@@ -46,7 +47,8 @@ test_that("scrub_interpolate updates confounds with nearest-neighbor edges", {
 
   out <- scrub_interpolate(infile, censor_file,
                            confound_files = conf_file,
-                           out_desc = "scrub", lg = lgr::get_logger_glue("BrainGnomes"))
+                           out_file = tempfile(fileext = ".nii.gz"),
+                           lg = lgr::get_logger_glue("BrainGnomes"))
 
   conf_new <- data.table::fread(conf_file, header = FALSE)[[1]]
   expected <- conf_df$a


### PR DESCRIPTION
## Summary
- compute postprocessing output filenames in the main loop
- simplify step functions to accept explicit output paths
- adjust confound processing and tests for new arguments

## Testing
- `R -q -e "devtools::test()"` *(fails: there is no package called ‘devtools’)*

------
https://chatgpt.com/codex/tasks/task_e_68b74fa24dd8832194eeac443c8a9430