### PR TITLE
feat: optional cleanup for AROMA outputs

### DIFF
--- a/R/process_subject.R
+++ b/R/process_subject.R
@@ -429,6 +429,14 @@ submit_aroma <- function(scfg, sub_dir = NULL, sub_id = NULL, ses_id = NULL, env
     glue("--derivatives fmriprep={scfg$metadata$fmriprep_directory}")
   ), collapse = TRUE)
 
+  cleanup <- isTRUE(scfg$aroma$cleanup)
+  if (cleanup && !is.null(scfg$fmriprep$output_spaces) &&
+      grepl("MNI152NLin6Asym:res-2", scfg$fmriprep$output_spaces, fixed = TRUE)) {
+    msg <- "AROMA cleanup requested but will not occur because MNI152NLin6Asym:res-2 is in fmriprep --output-spaces."
+    if (!is.null(lg)) lg$warn(msg) else warning(msg)
+    cleanup <- FALSE
+  }
+
   env_variables <- c(
     env_variables,
     aroma_container = scfg$compute_environment$aroma_container,
@@ -437,7 +445,8 @@ submit_aroma <- function(scfg, sub_dir = NULL, sub_id = NULL, ses_id = NULL, env
     loc_bids_root = scfg$metadata$bids_directory,
     loc_mrproc_root = scfg$metadata$fmriprep_directory,
     loc_scratch = scfg$metadata$scratch_directory,
-    cli_options = cli_options
+    cli_options = cli_options,
+    aroma_cleanup = as.integer(cleanup)
   )
 
   job_id <- cluster_job_submit(sched_script,

--- a/inst/hpc_scripts/aroma_subject.sbatch
+++ b/inst/hpc_scripts/aroma_subject.sbatch
@@ -43,6 +43,9 @@ else
   debug_pipeline=0
 fi
 
+# default to no cleanup if variable not provided
+[ -z "$aroma_cleanup" ] && aroma_cleanup=0
+
 # add the job id to the log file variables in case of crash
 [ -z "$stdout_log" ] && echo "stdout_log not set. Exiting." && exit 1
 [ -z "$stderr_log" ] && echo "stderr_log not set. Exiting." && exit 1
@@ -85,9 +88,14 @@ log_message DEBUG "Exit status of fmripost-aroma is $cmd_status, success is $suc
 
 [ -f "${loc_mrproc_root}/sub-${sub_id}.html" ] && mv "${loc_mrproc_root}/sub-${sub_id}.html" "${loc_mrproc_root}/sub-${sub_id}_aroma.html"
 [ -f "${loc_mrproc_root}/sub-${sub_id}_fmriprep.html" ] && mv "${loc_mrproc_root}/sub-${sub_id}_fmriprep.html" "${loc_mrproc_root}/sub-${sub_id}.html"
-
 # [[ $cmd_status -eq 0 && $debug_pipeline -eq 0 ]] && date +"%Y-%m-%d %H:%M:%S" > "$complete_file"
-[[ $success -eq 0 && $debug_pipeline -eq 0 ]] && date +"%Y-%m-%d %H:%M:%S" > "$complete_file"
+if [[ $success -eq 0 ]]; then
+  if [[ "$aroma_cleanup" == "TRUE" || "$aroma_cleanup" -eq 1 ]]; then
+    log_message INFO "Removing unneeded AROMA NIfTI/JSON files"
+    rel $rel_flag $log_flag find "$out_dir" -type f -name "*space-MNI152NLin6Asym_res-2*" -delete
+  fi
+  [[ $debug_pipeline -eq 0 ]] && date +"%Y-%m-%d %H:%M:%S" > "$complete_file"
+fi
 
 log_message INFO Exiting aroma for subject $sub_id "(time elapsed: $(time_elapsed))"
 exit $success

--- a/man/setup_aroma.Rd
+++ b/man/setup_aroma.Rd
@@ -33,5 +33,10 @@ By default, this function sets:
 \item \code{cli_options}: "" (any extra command-line flags for the wrapper)
 \item \code{sched_args}: "" (additional job scheduler directives)
 }
+
+Users may also opt to remove large intermediate AROMA NIfTI/JSON outputs after the job completes.
+These files are not required for applying AROMA during postprocessing and can be deleted to save disk space.
+Cleanup is only performed when fMRIPrep's output spaces do not include
+\code{MNI152NLin6Asym:res-2}; if that space is present, the files are retained.
 }
 \keyword{internal}

--- a/tests/example_config.yaml
+++ b/tests/example_config.yaml
@@ -64,6 +64,7 @@ aroma:
   ncores: 1.0
   cli_options: []
   sched_args: []
+  cleanup: yes
 postprocess:
   enable: yes
   memgb: 48.0


### PR DESCRIPTION
## Summary
- add optional cleanup prompt for AROMA setup
- pass cleanup flag to AROMA job submission
- remove large AROMA NIfTI/JSON outputs after successful run
- gate cleanup option when MNI152NLin6Asym:res-2 output space is requested

## Testing
- `apt-get update` *(warning: Failed to fetch https://mise.jdx.dev/deb/dists/stable/InRelease  Invalid response from proxy)*
- `R -q -e "install.packages(c('corpcor','lgr','RNifti','signal'), repos='https://cloud.r-project.org')"` *(fails: unable to access index for repository https://cloud.r-project.org/src/contrib)*
- `R -q -e "install.packages('devtools', repos='https://cloud.r-project.org')"` *(fails: unable to access index for repository https://cloud.r-project.org/src/contrib)*
- `R -q -e "devtools::document()"` *(fails: there is no package called 'devtools')*
- `R -q -e "devtools::test()"` *(fails: there is no package called 'devtools')*


------
https://chatgpt.com/codex/tasks/task_e_68b85e2123408321837f6f887065c18d