### PR TITLE
Enable toggling of processing modules in edit_project

### DIFF
--- a/R/edit_project.R
+++ b/R/edit_project.R
@@ -27,22 +27,24 @@ edit_project <- function(input = NULL) {
       "scheduler", "fmriprep_container", "heudiconv_container", "bids_validator", "mriqc_container", "aroma_container", "fsl_container"
     )),
     "Flywheel Sync" = list(setup_fn = setup_flywheel_sync, prefix = "flywheel_sync/", fields = c(
-      "source_url", "dropoff_directory", "temp_directory"
+      "enable", "source_url", "dropoff_directory", "temp_directory"
     )),
     "BIDS Conversion" = list(setup_fn = setup_bids_conversion, prefix = "bids_conversion/", fields = c(
-      "sub_regex", "sub_id_match", "ses_regex", "ses_id_match",
+      "enable", "sub_regex", "sub_id_match", "ses_regex", "ses_id_match",
       "heuristic_file", "overwrite", "clear_cache"
     )),
     "BIDS Validation" = list(setup_fn = setup_bids_validation, prefix = "bids_validation/", fields = c(
-      "outfile"
+      "enable", "outfile"
     )),
     "fMRIPrep" = list(setup_fn = setup_fmriprep, prefix = "fmriprep/", fields = c(
-      "output_spaces", "fs_license_file"
+      "enable", "output_spaces", "fs_license_file"
+    )),
+    "MRIQC" = list(setup_fn = setup_mriqc, prefix = "mriqc/", fields = c(
+      "enable"
+    )),
+    "ICA-AROMA" = list(setup_fn = setup_aroma, prefix = "aroma/", fields = c(
+      "enable", "cleanup"
     ))
-
-    # At present, MRIQC and ICA-AROMA don't have any additional specific settings, just job settings
-    # "MRIQC" = list(setup_fn = setup_mriqc, prefix = "mriqc/", fields = character(0)),
-    # "ICA-AROMA" = list(setup_fn = setup_aroma, prefix = "aroma/", fields = character(0))
   )
 
   job_targets <- c("flywheel_sync", "bids_conversion", "bids_validation", "fmriprep", "mriqc", "aroma", "postprocess", "extract_rois")
@@ -74,9 +76,9 @@ edit_project <- function(input = NULL) {
     }
 
     if (choice == "Postprocessing") {
-      scfg <- manage_postprocess_streams(scfg, allow_empty = TRUE)
+      scfg <- setup_postprocess_streams(scfg)
     } else if (choice == "ROI extraction") {
-      scfg <- manage_extract_streams(scfg)
+      scfg <- setup_extract_streams(scfg)
     } else if (choice == "Job settings") {
       # Job settings logic
       job <- select_list_safe(job_targets, title = "Select which job to configure:")

--- a/tests/testthat/test-edit_project.R
+++ b/tests/testthat/test-edit_project.R
@@ -1,0 +1,64 @@
+test_that("edit_project toggles BIDS Validation enable", {
+  scfg <- structure(list(
+    bids_validation = list(enable = TRUE, outfile = "out.html")
+  ), class = "bg_project_cfg")
+
+  sel_mock <- local({
+    i <- 0L
+    function(choices, title = NULL, multiple = FALSE) {
+      i <<- i + 1L
+      if (i == 1L) {
+        "BIDS Validation"
+      } else if (i == 2L) {
+        choices["enable"]
+      } else {
+        "Quit"
+      }
+    }
+  })
+
+  res <- with_mocked_bindings(
+    edit_project(scfg),
+    select_list_safe = sel_mock,
+    prompt_input = function(...) FALSE,
+    save_project_config = function(scfg) scfg
+  )
+
+  expect_false(res$bids_validation$enable)
+})
+
+test_that("edit_project toggles postprocess enable", {
+  tmpf <- tempfile()
+  file.create(tmpf)
+  scfg <- structure(list(
+    postprocess = list(enable = FALSE),
+    metadata = list(
+      fmriprep_directory = tempdir(),
+      postproc_directory = tempdir()
+    ),
+    compute_environment = list(fsl_container = tmpf)
+  ), class = "bg_project_cfg")
+
+  sel_mock <- local({
+    i <- 0L
+    function(choices, title = NULL, multiple = FALSE) {
+      i <<- i + 1L
+      if (i == 1L) {
+        "Postprocessing"
+      } else {
+        "Quit"
+      }
+    }
+  })
+
+  res <- with_mocked_bindings(
+    edit_project(scfg),
+    select_list_safe = sel_mock,
+    prompt_input = function(...) TRUE,
+    manage_postprocess_streams = function(scfg, allow_empty = TRUE) scfg,
+    save_project_config = function(scfg) scfg
+  )
+
+  expect_true(res$postprocess$enable)
+})
+


### PR DESCRIPTION
## Summary
- Allow `edit_project` to toggle `enable` flags for all processing modules
- Support MRIQC and ICA-AROMA in interactive project editing
- Add tests covering module and postprocessing enable toggling

## Testing
- `Rscript -e "testthat::test_local()"` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e4b59d1c8321b97d0630c90a9754