### PR TITLE
Validate aroma cleanup flag

### DIFF
--- a/R/setup_project.R
+++ b/R/setup_project.R
@@ -669,7 +669,7 @@ setup_bids_conversion <- function(scfg, fields = NULL) {
 #' - `sched_args`: "" (additional job scheduler directives)
 #'
 #' Users may also opt to remove large intermediate AROMA outputs after
-#' completion. These NIfTI/JSON files are not required for applying AROMA
+#' completion via the `cleanup` flag. These NIfTI/JSON files are not required for applying AROMA
 #' during postprocessing and can be deleted to save disk space. Cleanup is only
 #' available when fMRIPrep output spaces do not include
 #' `MNI152NLin6Asym:res-2`; if that space is later added, cleanup will be

--- a/R/validate_project.R
+++ b/R/validate_project.R
@@ -247,6 +247,12 @@ validate_project <- function(scfg = list(), quiet = FALSE) {
     }
   }
 
+  if (isTRUE(scfg$aroma$enable) && !checkmate::test_flag(scfg$aroma$cleanup)) {
+    message("Invalid cleanup flag in aroma. You will be asked for this.")
+    gaps <- c(gaps, "aroma/cleanup")
+    scfg$aroma$cleanup <- NULL
+  }
+
   # validate bids conversion
   scfg <- validate_bids_conversion(scfg, quiet = quiet)
   gaps <- c(gaps, attr(scfg, "gaps"))

--- a/man/setup_aroma.Rd
+++ b/man/setup_aroma.Rd
@@ -35,7 +35,7 @@ By default, this function sets:
 }
 
 Users may also opt to remove large intermediate AROMA outputs after
-completion. These NIfTI/JSON files are not required for applying AROMA
+completion via the \code{cleanup} flag. These NIfTI/JSON files are not required for applying AROMA
 during postprocessing and can be deleted to save disk space. Cleanup is only
 available when fMRIPrep output spaces do not include
 \code{MNI152NLin6Asym:res-2}; if that space is later added, cleanup will be


### PR DESCRIPTION
## Summary
- ensure `validate_project()` confirms `aroma/cleanup` is logical when AROMA is enabled
- clarify in AROMA setup docs that the `cleanup` flag removes intermediate outputs

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat", reporter="summary")'` *(fails: could not find functions and missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bf305aeb188321ba22bec984852d7c