### PR TITLE
Prompt for Flywheel CLI path during setup

### DIFF
--- a/R/edit_project.R
+++ b/R/edit_project.R
@@ -24,7 +24,7 @@ edit_project <- function(input = NULL) {
       "project_name", "project_directory", "dicom_directory", "bids_directory", "fmriprep_directory", "scratch_directory", "templateflow_home"
     )),
     "Compute Environment" = list(setup_fn = setup_compute_environment, prefix = "compute_environment/", fields = c(
-      "scheduler", "fmriprep_container", "heudiconv_container", "bids_validator", "mriqc_container", "aroma_container", "fsl_container"
+      "scheduler", "fmriprep_container", "heudiconv_container", "bids_validator", "mriqc_container", "aroma_container", "fsl_container", "flywheel"
     )),
     "Flywheel Sync" = list(setup_fn = setup_flywheel_sync, prefix = "flywheel_sync/", fields = c(
       "enable", "source_url", "dropoff_directory", "temp_directory"

--- a/R/validate_project.R
+++ b/R/validate_project.R
@@ -192,6 +192,11 @@ validate_project <- function(scfg = list(), quiet = FALSE) {
       message("Config file is missing valid directory for flywheel_sync/temp_directory.")
       gaps <- c(gaps, "flywheel_sync/temp_directory")
     }
+
+    if (!checkmate::test_file_exists(scfg$compute_environment$flywheel)) {
+      message("Flywheel sync is enabled but flywheel executable is missing. You will be asked for this.")
+      gaps <- c(gaps, "compute_environment/flywheel")
+    }
   }
 
   # step-specific required files


### PR DESCRIPTION
## Summary
- Prompt for Flywheel CLI location during Flywheel sync setup
- Auto-detect `fw` executable and confirm or request path in compute environment
- Validate and allow editing of Flywheel CLI path in project configuration

## Testing
- `R -q -e "devtools::document()"` *(fails: there is no package called ‘devtools’)*
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ffdf4b308321a9ef8e0596bbf472