### PR TITLE
Fix temporal filter handling and validation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # BrainGnomes 0.7-1
 
-* Clarified low_pass_hz and high_pass_hz settings in temporal filtering (postprocessing)
+* Fixed temporal_filter so omitting a high-pass cutoff no longer disables the requested low-pass filtering.
+* Corrected validation of band-pass cutoffs and clarified temporal filtering prompts/documentation.
 
 # BrainGnomes 0.7
 

--- a/R/postprocess_functions.R
+++ b/R/postprocess_functions.R
@@ -210,8 +210,10 @@ scrub_timepoints <- function(in_file, censor_file = NULL, out_file,
 #'
 #' @param in_file Path to the input 4D NIfTI file.
 #' @param out_file The full path for the file output by this step
-#' @param low_pass_hz Upper frequency cutoff in Hz. Frequencies above this are removed (low-pass). Use \code{NULL} to omit.
-#' @param high_pass_hz Lower frequency cutoff in Hz. Frequencies below this are removed (high-pass). Use \code{NULL} to omit.
+#' @param low_pass_hz Upper frequency cutoff in Hz. Frequencies above this are removed (low-pass).
+#'   Use \code{NULL} to omit the low-pass component (internally treated as \code{Inf}).
+#' @param high_pass_hz Lower frequency cutoff in Hz. Frequencies below this are removed (high-pass).
+#'   Use \code{NULL} or a non-positive value to omit the high-pass component (internally treated as \code{-Inf}).
 #' @param tr Repetition time (TR) in seconds. Required to convert Hz to volumes.
 #' @param overwrite Logical; whether to overwrite the output file if it exists.
 #' @param lg Optional lgr object used for logging messages
@@ -237,7 +239,7 @@ temporal_filter <- function(in_file, out_file, low_pass_hz=NULL, high_pass_hz=NU
   checkmate::assert_number(high_pass_hz, null.ok = TRUE, na.ok = FALSE)
   if (is.null(low_pass_hz) && is.null(high_pass_hz)) stop("low_pass_hz and high_pass_hz are NULL, so no filtering can occur")
   if (is.null(low_pass_hz)) low_pass_hz <- Inf
-  if (is.null(high_pass_hz) || abs(high_pass_hz) < 1e-6) low_pass_hz <- -Inf
+  if (is.null(high_pass_hz) || abs(high_pass_hz) < 1e-6) high_pass_hz <- -Inf
   
   stopifnot(low_pass_hz > high_pass_hz)
   checkmate::assert_number(tr, lower = 0.01)

--- a/R/setup_postprocess.R
+++ b/R/setup_postprocess.R
@@ -1015,7 +1015,7 @@ setup_temporal_filter <- function(ppcfg = list(), fields = NULL) {
   if ("postprocess/temporal_filter/high_pass_hz" %in% fields) {
     ppcfg$temporal_filter$high_pass_hz <- prompt_input(
       "Lower cutoff / high-pass threshold (Hz) ",
-      instruct = "Keeps frequencies above this cutoff and removes frequencies below it", 
+      instruct = "Keeps frequencies above this cutoff and removes frequencies below it. Leave blank to skip high-pass filtering.",
       type = "numeric", lower = 0, required = FALSE
     )
     if (is.na(ppcfg$temporal_filter$high_pass_hz)) {
@@ -1027,11 +1027,11 @@ setup_temporal_filter <- function(ppcfg = list(), fields = NULL) {
   if ("postprocess/temporal_filter/low_pass_hz" %in% fields) {
     ppcfg$temporal_filter$low_pass_hz <- prompt_input(
       "Upper cutoff / low-pass threshold (Hz)",
-      instruct = "Retains frequencies below this cutoff and removes frequencies above it", 
+      instruct = "Retains frequencies below this cutoff and removes frequencies above it. Leave blank to skip low-pass filtering.",
       type = "numeric", lower = 0, required = FALSE
     )
     if (is.na(ppcfg$temporal_filter$low_pass_hz)) {
-      cat("Omitting filtering of low frequencies\n")
+      cat("Omitting filtering of high frequencies\n")
       ppcfg$temporal_filter$low_pass_hz <- Inf # indicates no filtering out of high frequencies
     }
   }

--- a/R/validate_project.R
+++ b/R/validate_project.R
@@ -403,8 +403,8 @@ validate_postprocess_config_single <- function(ppcfg, cfg_name = NULL, quiet = F
       gaps <- c(gaps, "postprocess/temporal_filter/high_pass_hz")
       ppcfg$temporal_filter$high_pass_hz <- NULL
     }
-    if (!is.null(ppcfg$temporal_filter$low_pass_hz) && !is.null(ppcfg$temporal_filter$high_pass_hz) && 
-        ppcfg$temporal_filter$high_pass_hz < ppcfg$temporal_filter$low_pass_hz) {
+    if (!is.null(ppcfg$temporal_filter$low_pass_hz) && !is.null(ppcfg$temporal_filter$high_pass_hz) &&
+        ppcfg$temporal_filter$high_pass_hz > ppcfg$temporal_filter$low_pass_hz) {
       if (!quiet) message("high_pass_hz is greater than low_pass_hz $postprocess${cfg_name}$temporal_filter. You will be asked to respecify valid values.")
       gaps <- unique(c(gaps, "postprocess/temporal_filter/low_pass_hz", "postprocess/temporal_filter/high_pass_hz"))
       ppcfg$temporal_filter$low_pass_hz <- NULL

--- a/man/temporal_filter.Rd
+++ b/man/temporal_filter.Rd
@@ -7,8 +7,8 @@
 temporal_filter(
   in_file,
   out_file,
-  low_pass_hz = 0,
-  high_pass_hz = 1/120,
+  low_pass_hz = NULL,
+  high_pass_hz = NULL,
   tr = NULL,
   overwrite = FALSE,
   lg = NULL,
@@ -21,9 +21,11 @@ temporal_filter(
 
 \item{out_file}{The full path for the file output by this step}
 
-\item{low_pass_hz}{Lower frequency filter cutoff in Hz. Frequencies below this are removed. Use \code{0} to skip.}
+\item{low_pass_hz}{Upper frequency cutoff in Hz. Frequencies above this are removed (low-pass).
+Use \code{NULL} to omit the low-pass component (internally treated as \code{Inf}).}
 
-\item{high_pass_hz}{Higher frequency filter cutoff in Hz. Frequencies above this are removed. Use \code{Inf} to skip.}
+\item{high_pass_hz}{Lower frequency cutoff in Hz. Frequencies below this are removed (high-pass).
+Use \code{NULL} or a non-positive value to omit the high-pass component (internally treated as \code{-Inf}).}
 
 \item{tr}{Repetition time (TR) in seconds. Required to convert Hz to volumes.}
 

--- a/tests/testthat/test-temporal-filter.R
+++ b/tests/testthat/test-temporal-filter.R
@@ -1,0 +1,110 @@
+test_that("temporal_filter skips high-pass when cutoff omitted", {
+  commands <- character()
+  with_mocked_bindings({
+    temporal_filter(
+      in_file = "fake_input.nii.gz",
+      out_file = "fake_output.nii.gz",
+      low_pass_hz = 0.1,
+      high_pass_hz = NULL,
+      tr = 2,
+      method = "fslmaths"
+    )
+  }, run_fsl_command = function(args, ...) {
+    commands <<- c(commands, args)
+    invisible(NULL)
+  })
+
+  bptf_cmd <- commands[grepl("-bptf", commands, fixed = TRUE)]
+  expect_length(bptf_cmd, 1)
+  tokens <- strsplit(bptf_cmd, " ")[[1]]
+  idx <- which(tokens == "-bptf")
+  expect_length(idx, 1)
+  hp <- tokens[idx + 1]
+  lp <- tokens[idx + 2]
+  expect_identical(hp, "-1")
+  expect_gt(suppressWarnings(as.numeric(lp)), 0)
+})
+
+test_that("temporal_filter skips low-pass when cutoff omitted", {
+  commands <- character()
+  with_mocked_bindings({
+    temporal_filter(
+      in_file = "fake_input.nii.gz",
+      out_file = "fake_output.nii.gz",
+      low_pass_hz = NULL,
+      high_pass_hz = 0.01,
+      tr = 2,
+      method = "fslmaths"
+    )
+  }, run_fsl_command = function(args, ...) {
+    commands <<- c(commands, args)
+    invisible(NULL)
+  })
+
+  bptf_cmd <- commands[grepl("-bptf", commands, fixed = TRUE)]
+  expect_length(bptf_cmd, 1)
+  tokens <- strsplit(bptf_cmd, " ")[[1]]
+  idx <- which(tokens == "-bptf")
+  expect_length(idx, 1)
+  hp <- suppressWarnings(as.numeric(tokens[idx + 1]))
+  lp <- tokens[idx + 2]
+  expect_gt(hp, 0)
+  expect_identical(lp, "-1")
+})
+
+test_that("validate_postprocess_config_single accepts band-pass ordering", {
+  cfg <- list(
+    input_regex = "regex:.*",
+    bids_desc = "desc",
+    keep_intermediates = FALSE,
+    overwrite = FALSE,
+    tr = 2,
+    temporal_filter = list(
+      enable = TRUE,
+      low_pass_hz = 0.09,
+      high_pass_hz = 0.008,
+      prefix = "f",
+      method = "fslmaths"
+    ),
+    spatial_smooth = list(enable = FALSE),
+    intensity_normalize = list(enable = FALSE),
+    confound_calculate = list(enable = FALSE),
+    scrubbing = list(enable = FALSE),
+    confound_regression = list(enable = FALSE),
+    apply_mask = list(enable = FALSE),
+    apply_aroma = list(enable = FALSE),
+    force_processing_order = FALSE
+  )
+
+  res <- validate_postprocess_config_single(cfg, cfg_name = "test", quiet = TRUE)
+  expect_false(any(grepl("postprocess/temporal_filter", res$gaps, fixed = TRUE)))
+})
+
+test_that("validate_postprocess_config_single flags reversed band-pass", {
+  cfg <- list(
+    input_regex = "regex:.*",
+    bids_desc = "desc",
+    keep_intermediates = FALSE,
+    overwrite = FALSE,
+    tr = 2,
+    temporal_filter = list(
+      enable = TRUE,
+      low_pass_hz = 0.05,
+      high_pass_hz = 0.2,
+      prefix = "f",
+      method = "fslmaths"
+    ),
+    spatial_smooth = list(enable = FALSE),
+    intensity_normalize = list(enable = FALSE),
+    confound_calculate = list(enable = FALSE),
+    scrubbing = list(enable = FALSE),
+    confound_regression = list(enable = FALSE),
+    apply_mask = list(enable = FALSE),
+    apply_aroma = list(enable = FALSE),
+    force_processing_order = FALSE
+  )
+
+  res <- validate_postprocess_config_single(cfg, cfg_name = "test", quiet = TRUE)
+  expect_true("postprocess/temporal_filter/low_pass_hz" %in% res$gaps)
+  expect_true("postprocess/temporal_filter/high_pass_hz" %in% res$gaps)
+})


### PR DESCRIPTION
## Summary
- correct the temporal filter high-pass sentinel so low-pass-only filtering works and document the expected behaviour
- improve the setup prompts and project validation logic for temporal filter cutoffs
- add regression tests covering the bptf argument handling and band-pass validation and refresh the manual entry

## Testing
- `Rscript -e 'devtools::test()'` *(fails: missing packages `corpcor`, `lgr`, `RNifti`, `signal` in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d30e8c1d948321bd7daf2f4965e61b